### PR TITLE
Refactor parsers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,3 +25,5 @@ v0.12.0, 2020-05-15 -- Make category_id optional
 v1.0.0, 2020-06-03 -- Make session mandatory; stop using canonicalwebteam.http.CachedSession
 v1.0.1, 2020-07-15 -- Only strip space when there is space to strip
 v2.0.0, 2020-08-14 -- Discourse docs for engage pages and rename discourse_docs to discourse
+v2.0.1, 2020-09-15 -- Add getter function to return only a single engage page
+v2.0.2 2020-10-01 -- Refactor parsers

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,4 +26,4 @@ v1.0.0, 2020-06-03 -- Make session mandatory; stop using canonicalwebteam.http.C
 v1.0.1, 2020-07-15 -- Only strip space when there is space to strip
 v2.0.0, 2020-08-14 -- Discourse docs for engage pages and rename discourse_docs to discourse
 v2.0.1, 2020-09-15 -- Add getter function to return only a single engage page
-v2.0.2 2020-10-01 -- Refactor parsers
+v2.0.2, 2020-10-01 -- Refactor parsers

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -202,6 +202,7 @@ class EngagePages(object):
                     document=document,
                     forum_url=self.parser.api.base_url,
                     metadata=self.parser.metadata,
+                    takeovers=self.parser.takeovers,
                 )
             )
 

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -5,7 +5,8 @@ import re
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
 
-
+# Regex that matches Discourse topic URL
+# It is used to pull out the slug and topic_id
 TOPIC_URL_MATCH = re.compile(
     r"(?:/t)?(?:/(?P<slug>[^/]+))?/(?P<topic_id>\d+)(?:/\d+)?"
 )
@@ -74,12 +75,13 @@ class BaseParser(object):
 
         return BeautifulSoup(preamble_html, features="html.parser")
 
-    def _parse_metadata(self, index_soup):
+    def _parse_metadata(self, index_soup, section_name):
         """
         Given the HTML soup of an index topic
-        extract the metadata from the "Metadata" section.
+        extract the metadata from the name designated
+        by section_name
 
-        The Metadata section should contain a table
+        This section_name section should contain a table
         (extra markup around this table doesn't matter)
         e.g.:
 
@@ -116,7 +118,7 @@ class BaseParser(object):
             {"column-1": "data 3", "column-2": "data 4"},
         ]
         """
-        metadata_soup = self._get_section(index_soup, "Metadata")
+        metadata_soup = self._get_section(index_soup, section_name)
 
         topics_metadata = []
         if metadata_soup:

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -131,6 +131,14 @@ class BaseParser(object):
                 for index, value in enumerate(row.select("td")):
                     if value.find("a"):
                         row_dict["topic_name"] = value.find("a").text
+
+                    # Beautiful soup renders URLs as anchors
+                    # Avoid that default behaviour
+                    if value.find("a") and (
+                        value.find("a")["href"] == value.find("a").text
+                    ):
+                        value.contents[0] = value.find("a").text
+
                     row_dict[titles[index]] = "".join(
                         str(content) for content in value.contents
                     )

--- a/canonicalwebteam/discourse/parsers/docs_parser.py
+++ b/canonicalwebteam/discourse/parsers/docs_parser.py
@@ -18,14 +18,11 @@ from canonicalwebteam.discourse.exceptions import (
 )
 from canonicalwebteam.discourse.parsers.parsers import (
     TOPIC_URL_MATCH,
-    _get_section,
-    _get_preamble,
-    _parse_metadata,
-    _parse_url_map,
+    BaseParser,
 )
 
 
-class DocParser:
+class DocParser(BaseParser):
     def __init__(self, api, index_topic_id, url_prefix, category_id=None):
         self.api = api
         self.index_topic_id = index_topic_id
@@ -48,7 +45,7 @@ class DocParser:
         )
 
         # Parse URL & redirects mappings (get warnings)
-        self.url_map, url_warnings = _parse_url_map(
+        self.url_map, url_warnings = self._parse_url_map(
             raw_index_soup, self.url_prefix, self.index_topic_id, "URLs"
         )
         self.redirect_map, redirect_warnings = self._parse_redirect_map(
@@ -62,7 +59,7 @@ class DocParser:
             self.index_document["body_html"], features="html.parser"
         )
         self.index_document["body_html"] = str(
-            _get_preamble(index_soup, break_on_title="Navigation")
+            self._get_preamble(index_soup, break_on_title="Navigation")
         )
 
         # Parse navigation
@@ -71,7 +68,7 @@ class DocParser:
         self.metadata = None
         if self.category_id:
             topics = self.get_all_topics_category()
-            self.metadata = _parse_metadata(
+            self.metadata = self._parse_metadata(
                 self._replace_links(raw_index_soup, topics)
             )
 
@@ -155,7 +152,7 @@ class DocParser:
         links in the url_map
         """
 
-        nav_soup = _get_section(index_soup, "Navigation")
+        nav_soup = self._get_section(index_soup, "Navigation")
 
         if nav_soup:
             nav_html = str(self._replace_links(nav_soup))
@@ -260,7 +257,7 @@ class DocParser:
         | /some/other/path | https://example.com/cooler-place |
         """
 
-        redirect_soup = _get_section(index_soup, "Redirects")
+        redirect_soup = self._get_section(index_soup, "Redirects")
         redirect_map = {}
         warnings = []
 
@@ -528,7 +525,7 @@ class DocParser:
 
         for heading in headings:
             section = {}
-            section_soup = _get_section(soup, heading.text)
+            section_soup = self._get_section(soup, heading.text)
             first_child = section_soup.find() if section_soup else None
 
             if first_child and first_child.text.startswith("Duration"):

--- a/canonicalwebteam/discourse/parsers/docs_parser.py
+++ b/canonicalwebteam/discourse/parsers/docs_parser.py
@@ -16,7 +16,7 @@ from canonicalwebteam.discourse.exceptions import (
     PathNotFoundError,
     RedirectFoundError,
 )
-from canonicalwebteam.discourse.parsers.parsers import (
+from canonicalwebteam.discourse.parsers.base_parser import (
     TOPIC_URL_MATCH,
     BaseParser,
 )
@@ -69,7 +69,7 @@ class DocParser(BaseParser):
         if self.category_id:
             topics = self.get_all_topics_category()
             self.metadata = self._parse_metadata(
-                self._replace_links(raw_index_soup, topics)
+                self._replace_links(raw_index_soup, topics), "Metadata"
             )
 
     def resolve_path(self, relative_path):

--- a/canonicalwebteam/discourse/parsers/engage_parser.py
+++ b/canonicalwebteam/discourse/parsers/engage_parser.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 from canonicalwebteam.discourse.exceptions import (
     PathNotFoundError,
 )
-from canonicalwebteam.discourse.parsers.parsers import BaseParser
+from canonicalwebteam.discourse.parsers.base_parser import BaseParser
 
 
 class EngageParser(BaseParser):
@@ -44,9 +44,11 @@ class EngageParser(BaseParser):
         # Avoid markdown error to break site
         try:
             # Parse list of topics
-            self.metadata = self._parse_metadata(raw_index_soup)
+            self.metadata = self._parse_metadata(raw_index_soup, "Metadata")
+            self.takeovers = self._parse_metadata(raw_index_soup, "Takeovers")
         except IndexError:
             self.metadata = []
+            self.takeovers = []
             self.warnings.append("Failed to parse metadata correctly")
 
         if index_topic["id"] != self.index_topic_id:

--- a/canonicalwebteam/discourse/parsers/engage_parser.py
+++ b/canonicalwebteam/discourse/parsers/engage_parser.py
@@ -10,13 +10,10 @@ from bs4 import BeautifulSoup
 from canonicalwebteam.discourse.exceptions import (
     PathNotFoundError,
 )
-from canonicalwebteam.discourse.parsers.parsers import (
-    _parse_metadata,
-    _parse_url_map,
-)
+from canonicalwebteam.discourse.parsers.parsers import BaseParser
 
 
-class EngageParser:
+class EngageParser(BaseParser):
     """
     Parser exclusively for Engage pages
     """
@@ -40,14 +37,14 @@ class EngageParser:
         )
 
         # Parse URL
-        self.url_map, self.warnings = _parse_url_map(
+        self.url_map, self.warnings = self._parse_url_map(
             raw_index_soup, self.url_prefix, self.index_topic_id, "Metadata"
         )
 
         # Avoid markdown error to break site
         try:
             # Parse list of topics
-            self.metadata = _parse_metadata(raw_index_soup)
+            self.metadata = self._parse_metadata(raw_index_soup)
         except IndexError:
             self.metadata = []
             self.warnings.append("Failed to parse metadata correctly")
@@ -147,6 +144,10 @@ class EngageParser:
         return topic_id
 
     def get_topic(self, topic_id):
+        """
+        Receives a single topic_id and
+        @return the content of the topic
+        """
         index_topic = self.api.get_topic(topic_id)
         return self.parse_topic(index_topic)
 

--- a/canonicalwebteam/discourse/parsers/parsers.py
+++ b/canonicalwebteam/discourse/parsers/parsers.py
@@ -11,209 +11,213 @@ TOPIC_URL_MATCH = re.compile(
 )
 
 
-def _get_section(soup, title_text):
+class BaseParser(object):
     """
-    Given some HTML soup and the text of a title within it,
-    get the content between that title and the next title
-    of the same level, and return it as another soup object.
-
-    E.g. if `soup` contains is:
-
-    <p>Pre</p>
-    <h2>My heading</h2>
-    <p>Content</p>
-    <h2>Next heading</h2>
-
-    and `title_text` is "My heading", then it will return:
-
-    <p>Content</p>
+    Parsers used commonly by Docs and Engage pages
     """
 
-    heading = soup.find(re.compile("^h[1-6]$"), text=title_text)
+    def _get_section(self, soup, title_text):
+        """
+        Given some HTML soup and the text of a title within it,
+        get the content between that title and the next title
+        of the same level, and return it as another soup object.
 
-    if not heading:
-        return None
+        E.g. if `soup` contains is:
 
-    heading_tag = heading.name
+        <p>Pre</p>
+        <h2>My heading</h2>
+        <p>Content</p>
+        <h2>Next heading</h2>
 
-    section_html = "".join(map(str, heading.fetchNextSiblings()))
-    section_soup = BeautifulSoup(section_html, features="html.parser")
+        and `title_text` is "My heading", then it will return:
 
-    # If there's another heading of the same level
-    # get the content before it
-    next_heading = section_soup.find(heading_tag)
-    if next_heading:
-        section_elements = next_heading.fetchPreviousSiblings()
-        section_elements.reverse()
-        section_html = "".join(map(str, section_elements))
+        <p>Content</p>
+        """
+
+        heading = soup.find(re.compile("^h[1-6]$"), text=title_text)
+
+        if not heading:
+            return None
+
+        heading_tag = heading.name
+
+        section_html = "".join(map(str, heading.fetchNextSiblings()))
         section_soup = BeautifulSoup(section_html, features="html.parser")
 
-    return section_soup
+        # If there's another heading of the same level
+        # get the content before it
+        next_heading = section_soup.find(heading_tag)
+        if next_heading:
+            section_elements = next_heading.fetchPreviousSiblings()
+            section_elements.reverse()
+            section_html = "".join(map(str, section_elements))
+            section_soup = BeautifulSoup(section_html, features="html.parser")
 
+        return section_soup
 
-def _get_preamble(soup, break_on_title):
-    """
-    Given a BeautifulSoup HTML document,
-    separate out the HTML at the start, up to
-    the heading defined in `break_on_title`,
-    and return it as a BeautifulSoup object
-    """
+    def _get_preamble(self, soup, break_on_title):
+        """
+        Given a BeautifulSoup HTML document,
+        separate out the HTML at the start, up to
+        the heading defined in `break_on_title`,
+        and return it as a BeautifulSoup object
+        """
 
-    heading = soup.find(re.compile("^h[1-6]$"), text=break_on_title)
+        heading = soup.find(re.compile("^h[1-6]$"), text=break_on_title)
 
-    if not heading:
-        return soup
+        if not heading:
+            return soup
 
-    preamble_elements = heading.fetchPreviousSiblings()
-    preamble_elements.reverse()
-    preamble_html = "".join(map(str, preamble_elements))
+        preamble_elements = heading.fetchPreviousSiblings()
+        preamble_elements.reverse()
+        preamble_html = "".join(map(str, preamble_elements))
 
-    return BeautifulSoup(preamble_html, features="html.parser")
+        return BeautifulSoup(preamble_html, features="html.parser")
 
+    def _parse_metadata(self, index_soup):
+        """
+        Given the HTML soup of an index topic
+        extract the metadata from the "Metadata" section.
 
-def _parse_metadata(index_soup):
-    """
-    Given the HTML soup of an index topic
-    extract the metadata from the "Metadata" section.
+        The Metadata section should contain a table
+        (extra markup around this table doesn't matter)
+        e.g.:
 
-    The Metadata section should contain a table
-    (extra markup around this table doesn't matter)
-    e.g.:
+        <h1>Metadata</h1>
+        <details>
+            <summary>Mapping table</summary>
+            <table>
+            <tr><th>Column 1</th><th>Column 2</th></tr>
+            <tr>
+                <td>data 1</td>
+                <td>data 2</td>
+            </tr>
+            <tr>
+                <td>data 3</td>
+                <td>data 4</td>
+            </tr>
+            </table>
+        </details>
 
-    <h1>Metadata</h1>
-    <details>
-        <summary>Mapping table</summary>
-        <table>
-        <tr><th>Column 1</th><th>Column 2</th></tr>
-        <tr>
-            <td>data 1</td>
-            <td>data 2</td>
-        </tr>
-        <tr>
-            <td>data 3</td>
-            <td>data 4</td>
-        </tr>
-        </table>
-    </details>
+        This will typically be generated in Discourse from Markdown similar to
+        the following:
 
-    This will typically be generated in Discourse from Markdown similar to
-    the following:
+        # Redirects
 
-    # Redirects
+        [details=Mapping table]
+        | Column 1| Column 2|
+        | -- | -- |
+        | data 1 | data 2 |
+        | data 3 | data 4 |
 
-    [details=Mapping table]
-    | Column 1| Column 2|
-    | -- | -- |
-    | data 1 | data 2 |
-    | data 3 | data 4 |
-
-    The function will return a list of dictionaries of this format:
-    [
-        {"column-1": "data 1", "column-2": "data 2"},
-        {"column-1": "data 3", "column-2": "data 4"},
-    ]
-    """
-    metadata_soup = _get_section(index_soup, "Metadata")
-
-    topics_metadata = []
-    if metadata_soup:
-        titles = [
-            title_soup.text.lower().replace(" ", "_").replace("-", "_")
-            for title_soup in metadata_soup.select("th")
+        The function will return a list of dictionaries of this format:
+        [
+            {"column-1": "data 1", "column-2": "data 2"},
+            {"column-1": "data 3", "column-2": "data 4"},
         ]
-        for row in metadata_soup.select("tr:has(td)"):
-            row_dict = {}
-            for index, value in enumerate(row.select("td")):
-                if value.find("a"):
-                    row_dict["topic_name"] = value.find("a").text
-                row_dict[titles[index]] = "".join(
-                    str(content) for content in value.contents
-                )
+        """
+        metadata_soup = self._get_section(index_soup, "Metadata")
 
-            topics_metadata.append(row_dict)
+        topics_metadata = []
+        if metadata_soup:
+            titles = [
+                title_soup.text.lower().replace(" ", "_").replace("-", "_")
+                for title_soup in metadata_soup.select("th")
+            ]
+            for row in metadata_soup.select("tr:has(td)"):
+                row_dict = {}
+                for index, value in enumerate(row.select("td")):
+                    if value.find("a"):
+                        row_dict["topic_name"] = value.find("a").text
+                    row_dict[titles[index]] = "".join(
+                        str(content) for content in value.contents
+                    )
 
-    return topics_metadata
+                topics_metadata.append(row_dict)
 
+        return topics_metadata
 
-def _parse_url_map(index_soup, url_prefix, index_topic_id, url_section_name):
-    """
-    Given the HTML soup of an index topic
-    extract the URL mappings from a "URLs" section.
+    def _parse_url_map(
+        self, index_soup, url_prefix, index_topic_id, url_section_name
+    ):
+        """
+        Given the HTML soup of an index topic
+        extract the URL mappings from a "URLs" section.
 
-    This section could be called whatever is
-    passed in `url_section_name` but it must
-    contain a table of
-    "Topic" to "Path" mappings
-    (extra markup around this table doesn't matter)
-    e.g.:
+        This section could be called whatever is
+        passed in `url_section_name` but it must
+        contain a table of
+        "Topic" to "Path" mappings
+        (extra markup around this table doesn't matter)
+        e.g.:
 
-    <h1>URLs</h1>
-    <details>
-        <summary>Mapping table</summary>
-        <table>
-        <tr><th>Topic</th><th>Path</th></tr>
-        <tr>
-            <td><a href="https://forum.example.com/t/page/10">Page</a></td>
-            <td>/cool-page</td>
-        </tr>
-        <tr>
-            <td>
-                <a href="https://forum.example.com/t/place/11">Place</a>
-            </td>
-            <td>/cool-place</td>
-        </tr>
-        </table>
-    </details>
+        <h1>URLs</h1>
+        <details>
+            <summary>Mapping table</summary>
+            <table>
+            <tr><th>Topic</th><th>Path</th></tr>
+            <tr>
+                <td><a href="https://forum.example.com/t/page/10">Page</a></td>
+                <td>/cool-page</td>
+            </tr>
+            <tr>
+                <td>
+                    <a href="https://forum.example.com/t/place/11">Place</a>
+                </td>
+                <td>/cool-place</td>
+            </tr>
+            </table>
+        </details>
 
-    This will typically be generated in Discourse from Markdown similar to
-    the following:
+        This will typically be generated in Discourse from Markdown similar to
+        the following:
 
-    # URLs
+        # URLs
 
-    [details=Mapping table]
-    | Topic | Path |
-    | -- | -- |
-    | https://forum.example.com/t/place/11| /cool-page |
-    | https://forum.example.com/t/place/11  | /cool-place |
+        [details=Mapping table]
+        | Topic | Path |
+        | -- | -- |
+        | https://forum.example.com/t/place/11| /cool-page |
+        | https://forum.example.com/t/place/11  | /cool-place |
 
-    """
+        """
 
-    url_soup = _get_section(index_soup, url_section_name)
-    url_map = {}
-    warnings = []
+        url_soup = self._get_section(index_soup, url_section_name)
+        url_map = {}
+        warnings = []
 
-    if url_soup:
-        for row in url_soup.select("tr:has(td)"):
-            topic_a = row.select_one("td:first-child a[href]")
-            path_td = row.select_one("td:nth-child(2)")
+        if url_soup:
+            for row in url_soup.select("tr:has(td)"):
+                topic_a = row.select_one("td:first-child a[href]")
+                path_td = row.select_one("td:nth-child(2)")
 
-            if not topic_a or not path_td:
-                warnings.append("Could not parse URL map item {item}")
-                continue
+                if not topic_a or not path_td:
+                    warnings.append("Could not parse URL map item {item}")
+                    continue
 
-            topic_url = topic_a.attrs.get("href", "")
-            topic_path = urlparse(topic_url).path
-            topic_match = TOPIC_URL_MATCH.match(topic_path)
+                topic_url = topic_a.attrs.get("href", "")
+                topic_path = urlparse(topic_url).path
+                topic_match = TOPIC_URL_MATCH.match(topic_path)
 
-            pretty_path = path_td.text
+                pretty_path = path_td.text
 
-            if not topic_match or not pretty_path.startswith(url_prefix):
-                warnings.append("Could not parse URL map item {item}")
-                continue
+                if not topic_match or not pretty_path.startswith(url_prefix):
+                    warnings.append("Could not parse URL map item {item}")
+                    continue
 
-            topic_id = int(topic_match.groupdict()["topic_id"])
+                topic_id = int(topic_match.groupdict()["topic_id"])
 
-            url_map[pretty_path] = topic_id
+                url_map[pretty_path] = topic_id
 
-    # Add the reverse mappings as well, for efficiency
-    ids_to_paths = dict([reversed(pair) for pair in url_map.items()])
-    url_map.update(ids_to_paths)
+        # Add the reverse mappings as well, for efficiency
+        ids_to_paths = dict([reversed(pair) for pair in url_map.items()])
+        url_map.update(ids_to_paths)
 
-    # Add the homepage path
-    home_path = url_prefix
-    if home_path != "/" and home_path.endswith("/"):
-        home_path = home_path.rstrip("/")
-    url_map[home_path] = index_topic_id
-    url_map[index_topic_id] = home_path
+        # Add the homepage path
+        home_path = url_prefix
+        if home_path != "/" and home_path.endswith("/"):
+            home_path = home_path.rstrip("/")
+        url_map[home_path] = index_topic_id
+        url_map[index_topic_id] = home_path
 
-    return url_map, warnings
+        return url_map, warnings

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="2.0.1",
+    version="2.0.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,11 +10,8 @@ import requests
 from bs4 import BeautifulSoup
 
 # Local
-from canonicalwebteam.discourse import (
-    Docs,
-    DiscourseAPI,
-    DocParser,
-)
+from canonicalwebteam.discourse import Docs, DiscourseAPI, DocParser
+from canonicalwebteam.discourse.parsers.base_parser import TOPIC_URL_MATCH
 from tests.fixtures.forum_mock import register_uris
 
 
@@ -486,3 +483,13 @@ class TestApp(unittest.TestCase):
             b"http://localhost/a\nhttp://localhost/page-z\nhttp://localhost/",
             response.data,
         )
+
+    def test_topic_match_regex(self):
+        """
+        Test Regex TOPIC_URL_MATCH
+        """
+
+        url = "/t/topic-name/12346"
+        match = TOPIC_URL_MATCH.match(url).groupdict()
+        self.assertEqual(match["slug"], "topic-name")
+        self.assertEqual(match["topic_id"], "12346")


### PR DESCRIPTION
## Done

- Refactor parsers by creating a Base class to extend from as per discussion.
- Return takeovers
- Fix default discourse behavior of turning URLs into anchors

## QA
- Checkout this PR https://github.com/canonical-web-and-design/ubuntu.com/pull/8414 
- `docker-compose up -d` if you haven't done it before
- `dotrun --env DISCOURSE_API_KEY=API-key --env DISCOURSE_API_USERNAME="carkod" ` Get the API-Key in Last Pass

Make sure there is nothing broken by visiting:
- `/tutorials`
- `/server/docs`
- `/engage`
- FInally check that json data for takeovers is showing up on `/`

## Issue

Fixes #49