### PR TITLE
Remove meta div that breaks Vanilla

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,3 +27,4 @@ v1.0.1, 2020-07-15 -- Only strip space when there is space to strip
 v2.0.0, 2020-08-14 -- Discourse docs for engage pages and rename discourse_docs to discourse
 v2.0.1, 2020-09-15 -- Add getter function to return only a single engage page
 v2.0.2, 2020-10-01 -- Refactor parsers
+v2.0.3, 2020-10-22 -- Remove meta div that breaks Vanilla

--- a/canonicalwebteam/discourse/parsers/docs_parser.py
+++ b/canonicalwebteam/discourse/parsers/docs_parser.py
@@ -364,8 +364,7 @@ class DocParser(BaseParser):
 
     def _replace_lightbox(self, soup):
         for lightbox in soup.findAll("div", {"class": "lightbox-wrapper"}):
-            image = lightbox.find("img")
-            lightbox.replace_with(image)
+            lightbox.find("div", {"class": "meta"}).decompose()
 
     def _replace_polls(self, soup):
         """


### PR DESCRIPTION
## Done

Improve current lightbox solution, by removing meta div.
This addresses the Anbox-cloud issue where images are too small (see issue below). This solution emulates a "lightbox", by allowing the user to click on the image, since we cannot recreate lightbox effect as it needs JS.

## QA

- Install this version on anbox-cloud project by adding `git+git://github.com/carkod/canonicalwebteam.discourse.git@replace-lightbox#egg=canonicalwebteam.discourse` to requirements.txt
- `dotrun clean`
- `dotrun`
- Go to `/docs/manage/streaming-android-applications` and check that the image can be opened in a larger view.
- As a comparison, you can check the current ubuntu.com/docs/manage/streaming-android-applications to see the difference

### Additional checks

- Install this version on ubuntu.com project by adding `git+git://github.com/carkod/canonicalwebteam.discourse.git@replace-lightbox#egg=canonicalwebteam.discourse` to requirements.txt
- `dotrun clean` (to clean previous version of discourse, you may have discourse-docs instead of discourse installed)
- `dotrun`
- Check that `/tutorials` does not have any images broken.

## Issue
Fixes #46 
