### PR TITLE
Make url_prefix optionnal in url map

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,3 +28,4 @@ v2.0.0, 2020-08-14 -- Discourse docs for engage pages and rename discourse_docs 
 v2.0.1, 2020-09-15 -- Add getter function to return only a single engage page
 v2.0.2, 2020-10-01 -- Refactor parsers
 v2.0.3, 2020-10-22 -- Remove meta div that breaks Vanilla
+v2.0.4, 2020-11-12 -- Make url prefix optional on url map

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -210,6 +210,10 @@ class BaseParser(object):
                 topic_match = TOPIC_URL_MATCH.match(topic_path)
 
                 pretty_path = path_td.text
+                if not pretty_path.startswith("/"):
+                    pretty_path = "/" + pretty_path
+                if not pretty_path.startswith(url_prefix):
+                    pretty_path = url_prefix + pretty_path
 
                 if not topic_match or not pretty_path.startswith(url_prefix):
                     warnings.append("Could not parse URL map item {item}")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="2.0.2",
+    version="2.0.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/fixtures/forum_mock.py
+++ b/tests/fixtures/forum_mock.py
@@ -257,6 +257,53 @@ def register_uris():
     # Basic topic page with minimal content
     httpretty.register_uri(
         httpretty.GET,
+        "https://discourse.example.com/t/11.json",
+        body=json.dumps(
+            {
+                "id": 11,
+                "category_id": 2,
+                "title": "Page A",
+                "slug": "page-a",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 56,
+                            "cooked": ("<p>Content of this page</p>"),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ]
+                },
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Basic topic page with minimal content
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://discourse.example.com/t/12.json",
+        body=json.dumps(
+            {
+                "id": 12,
+                "category_id": 2,
+                "title": "Page A",
+                "slug": "page-a",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 56,
+                            "cooked": ("<p>Content of this page</p>"),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ]
+                },
+            }
+        ),
+        content_type="application/json",
+    )
+    # Basic topic page with minimal content
+    httpretty.register_uri(
+        httpretty.GET,
         "https://discourse.example.com/t/42.json",
         body=json.dumps(
             {
@@ -404,4 +451,75 @@ def register_uris():
                 }
             }
         ),
+    )
+
+    # Mock with URL map that has field with prefix and some with not
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://discourse.example.com/t/38.json",
+        body=json.dumps(
+            {
+                "id": 38,
+                "category_id": 2,
+                "title": "An index page",
+                "slug": "an-index-page",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 3434,
+                            "cooked": (
+                                "<p>Some homepage content</p>"
+                                "<h1>Navigation</h1>"
+                                "<ul>"
+                                '<li><a href="/t/page-a/10">Page A</a></li>'
+                                '<li><a href="/t/b-page/12">B page</a></li>'
+                                "</ul>"
+                                "<h1>URLs</h1>"
+                                '<details open="">'
+                                "<summary>Mapping table</summary>"
+                                '<div class="md-table">'
+                                "<table>"
+                                "<thead><tr>"
+                                "<th>Topic</th><th>Path</th></tr></thead>"
+                                "<tbody><tr>"
+                                '<td><a href="https://discourse.example.com/t/'
+                                'page-a/10">Page A</a></td>'
+                                "<td>/docs/a</td>"
+                                "</tr><tr>"
+                                '<td><a href="https://discourse.example.com/t/'
+                                'page-b/11">Page B</a></td>'
+                                "<td>b</td>"
+                                "</tr><tr>"
+                                '<td><a href="https://discourse.example.com/t/'
+                                'page-b/12">Page C</a></td>'
+                                "<td>c</td>"
+                                "</tr><tr>"
+                                '<td><a href="https://discourse.example.com/t/'
+                                'page-z/26">Page Z</a></td>'
+                                "<td>/page-z</td>"
+                                "</tr></tbody></table>"
+                                "</div></details>"
+                                "<h1>Redirects</h1>"
+                                '<details open="">'
+                                "<summary>Mapping table</summary>"
+                                '<div class="md-table">'
+                                "<table>"
+                                "<thead><tr>"
+                                "<th>Topic</th><th>Path</th></tr></thead>"
+                                "<tbody>"
+                                "<tr><td>/redir-a</td><td>/a</td></tr>"
+                                "<tr>"
+                                "  <td>/example/page</td>"
+                                "  <td>https://example.com/page</td>"
+                                "</tr>"
+                                "</tr></tbody></table>"
+                                "</div></details>"
+                            ),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ]
+                },
+            }
+        ),
+        content_type="application/json",
     )


### PR DESCRIPTION
# Summary

Make the url_prefix optional in the url_map

The URL map can look like this now, if `url_prefix==/docs`:

```
# URLs

[details=Mapping table]

| Topic | Slug |
| -- | -- |
| <discourse_url> | /toto |
| <discourse_url> | tata |
| <discourse_url> | /docs/titi |
[/details]
```

This means that: 
```
# URLs

[details=Mapping table]

| Topic | Slug |
| -- | -- |
| <discourse_url> | /toto |   -> /docs/toto
| <discourse_url> | tata |   -> /docs/tata
| <discourse_url> | /docs/titi |    -> /docs/titi
[/details]
```

# QA

- add this module to charmhub
- Run charmhub with module and go on:
- http://0.0.0.0:8045/mattermost/docs
- Compare with URL map here: https://discourse.charmhub.io/t/mattermost-documentation-overview/3758
