### PR TITLE
Add preview feature

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,3 +29,4 @@ v2.0.1, 2020-09-15 -- Add getter function to return only a single engage page
 v2.0.2, 2020-10-01 -- Refactor parsers
 v2.0.3, 2020-10-22 -- Remove meta div that breaks Vanilla
 v2.0.4, 2020-11-12 -- Make url prefix optional on url map
+v2.0.5, 2020-11-18 -- Add preview option for inactive pages

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -180,6 +180,7 @@ class EngagePages(object):
             if path == "/":
                 document = self.parser.index_document
             else:
+                preview = flask.request.args.get("preview")
 
                 try:
                     topic_id = self.parser.resolve_path(path)
@@ -195,6 +196,15 @@ class EngagePages(object):
                     return flask.abort(http_error.response.status_code)
 
                 document = self.parser.parse_topic(topic)
+
+                if (
+                    preview is None
+                    and "active" in document["metadata"]
+                    and document["metadata"]["active"] == "false"
+                ):
+                    return flask.redirect(
+                        f"{self.parser.api.base_url}{document['topic_path']}"
+                    )
 
             response = flask.make_response(
                 flask.render_template(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="2.0.3",
+    version="2.0.5",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/cassettes/TestDiscourseAPI.test_active_page_returns_200.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_active_page_returns_200.yaml
@@ -1,0 +1,2522 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/17229.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
+        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
+        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
+        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
+        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
+        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
+        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
+        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
+        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
+        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
+        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
+        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
+        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
+        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
+        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
+        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
+        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
+        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
+        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
+        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
+        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
+        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
+        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
+        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
+        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
+        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
+        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
+        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
+        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
+        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
+        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
+        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
+        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
+        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
+        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
+        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
+        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
+        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
+        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
+        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
+        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
+        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
+        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
+        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
+        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
+        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
+        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
+        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
+        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
+        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
+        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
+        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
+        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
+        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
+        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
+        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
+        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
+        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
+        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
+        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
+        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
+        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
+        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
+        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
+        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
+        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
+        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
+        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
+        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
+        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
+        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
+        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
+        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
+        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
+        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
+        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
+        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
+        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
+        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
+        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
+        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
+        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
+        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
+        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
+        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
+        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
+        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
+        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
+        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
+        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
+        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
+        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
+        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
+        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
+        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
+        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
+        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
+        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
+        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
+        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
+        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
+        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
+        \ MicroK8s, what it is and why you should use it. This event will also include\
+        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
+        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
+        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
+        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
+        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
+        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
+        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
+        \ initial deployment and reduce operational costs by outsourcing private cloud\
+        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
+        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
+        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
+        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
+        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
+        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
+        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
+        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
+        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
+        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
+        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
+        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
+        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
+        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
+        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
+        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
+        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
+        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
+        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
+        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
+        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
+        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
+        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
+        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
+        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
+        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
+        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
+        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
+        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
+        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
+        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
+        \ live-migration extensions for easier infrastructure deployments and more.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
+        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
+        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
+        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
+        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
+        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
+        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
+        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
+        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
+        \ Proxy overcomes challenges presented by restricted networks and management\
+        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
+        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
+        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
+        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
+        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
+        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
+        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
+        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
+        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
+        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
+        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
+        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
+        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
+        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
+        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
+        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
+        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
+        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
+        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
+        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
+        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
+        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
+        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
+        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
+        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
+        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
+        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
+        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
+        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
+        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
+        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
+        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
+        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
+        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
+        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
+        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
+        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
+        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
+        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
+        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
+        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
+        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
+        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
+        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
+        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
+        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
+        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
+        \ provides enterprises with real-time data processing, cost-effective security\
+        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
+        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
+        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
+        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
+        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
+        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
+        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
+        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
+        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
+        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
+        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
+        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
+        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
+        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
+        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
+        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
+        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
+        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
+        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
+        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
+        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
+        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
+        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
+        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
+        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
+        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
+        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
+        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
+        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
+        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
+        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
+        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
+        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
+        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
+        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
+        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
+        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
+        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
+        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
+        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
+        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
+        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Trilio and Canonical help organisations transition to new, maintainable\
+        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
+        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
+        \ on drones to replace human workers in potentially dangerous scenarios.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
+        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
+        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
+        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
+        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
+        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
+        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
+        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
+        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
+        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
+        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
+        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
+        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
+        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
+        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
+        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
+        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
+        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
+        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
+        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
+        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
+        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
+        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
+        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
+        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
+        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
+        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
+        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
+        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
+        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
+        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
+        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
+        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
+        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
+        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
+        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
+        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
+        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
+        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
+        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
+        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
+        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
+        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
+        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
+        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
+        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
+        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
+        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
+        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
+        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
+        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
+        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
+        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
+        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
+        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
+        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
+        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
+        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
+        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
+        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
+        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
+        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
+        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
+        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
+        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
+        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eA deep dive into securing against the threats of cyber attacks and data\
+        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
+        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
+        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
+        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
+        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
+        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
+        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
+        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
+        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
+        \ for the ultimate edge device including development, extensibility, risk\
+        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
+        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
+        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
+        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
+        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
+        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Apellix has designed revolutionary software to solve industrial IoT\
+        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
+        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
+        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
+        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
+        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ about Ubuntu CIS and FIPS certified components to enable operating under\
+        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
+        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
+        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
+        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
+        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
+        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
+        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
+        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
+        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
+        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
+        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
+        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
+        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
+        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
+        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
+        :1,\"updated_at\":\"2020-11-18T12:27:45.618Z\",\"reply_count\":0,\"reply_to_post_number\"\
+        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
+        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
+        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":26,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
+        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
+        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
+        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
+        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
+        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
+        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
+        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
+        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
+        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
+        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
+        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
+        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
+        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
+        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
+        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
+        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
+        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
+        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
+        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
+        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
+        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
+        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
+        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
+        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
+        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
+        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
+        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
+        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
+        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
+        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
+        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
+        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
+        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
+        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
+        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
+        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
+        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
+        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
+        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
+        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
+        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
+        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
+        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
+        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
+        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
+        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
+        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
+        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
+        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
+        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
+        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
+        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
+        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
+        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
+        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
+        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
+        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
+        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
+        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
+        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
+        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
+        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
+        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
+        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
+        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
+        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
+        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
+        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
+        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
+        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
+        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
+        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
+        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
+        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
+        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
+        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
+        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
+        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
+        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
+        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
+        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
+        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
+        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
+        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
+        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
+        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
+        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
+        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
+        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
+        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
+        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
+        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
+        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
+        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
+        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
+        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
+        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
+        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
+        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
+        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
+        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
+        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
+        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
+        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
+        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
+        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
+        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
+        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
+        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
+        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
+        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
+        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
+        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
+        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
+        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
+        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
+        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
+        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
+        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
+        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
+        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
+        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
+        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
+        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
+        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
+        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
+        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
+        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
+        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
+        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
+        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
+        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
+        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[48547]},\"timeline_lookup\":[[1,127]],\"suggested_topics\":[{\"id\":17389,\"\
+        title\":\"Leveraging open source with Ubuntu Pro on Azure\",\"fancy_title\"\
+        :\"Leveraging open source with Ubuntu Pro on Azure\",\"slug\":\"leveraging-open-source-with-ubuntu-pro-on-azure\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:08:24.599Z\",\"last_posted_at\":\"2020-07-17T16:08:24.765Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:08:24.765Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":132,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17412,\"title\":\"Canonical int\xE8gre containerd \xE0 Ubuntu\
+        \ Kubernetes\",\"fancy_title\":\"Canonical int\xE8gre containerd \xE0 Ubuntu\
+        \ Kubernetes\",\"slug\":\"canonical-integre-containerd-a-ubuntu-kubernetes\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:33:36.646Z\",\"last_posted_at\":\"2020-07-17T16:33:36.809Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:33:36.809Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":47,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17384,\"title\":\"OpenStack deployment guide\",\"fancy_title\"\
+        :\"OpenStack deployment guide\",\"slug\":\"openstack-deployment-guide\",\"\
+        posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:04:01.257Z\",\"last_posted_at\":\"2020-07-17T16:04:01.377Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-08-04T12:39:29.646Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":152,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17362,\"title\":\"Linux security with Ubuntu\",\"fancy_title\"\
+        :\"Linux security with Ubuntu\",\"slug\":\"linux-security-with-ubuntu\",\"\
+        posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T14:35:56.497Z\",\"last_posted_at\":\"2020-07-17T14:35:56.616Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T14:35:56.616Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":135,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17418,\"title\":\"Installez et mettez OpenStack \xE0 l'\xE9chelle\
+        \ en toute simplicit\xE9\",\"fancy_title\":\"Installez et mettez OpenStack\
+        \ \xE0 l\\u0026rsquo;\xE9chelle en toute simplicit\xE9\",\"slug\":\"installez-et-mettez-openstack-a-lechelle-en-toute-simplicite\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:42:33.473Z\",\"last_posted_at\":\"2020-07-17T16:42:33.705Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:42:33.705Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":134,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
+        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
+        :\"2020-07-14T09:57:15.561Z\",\"views\":345,\"reply_count\":0,\"like_count\"\
+        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
+        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
+        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
+        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":221,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
+        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
+        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
+        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
+        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
+        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
+        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
+        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
+        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
+        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
+        :\"ubuntu.com\"}]}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 22:48:14 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Cached:
+      - 'true'
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 3b7f0d67-14e6-4a5e-928e-aef074a99a08
+      X-Runtime:
+      - '0.002467'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/19304.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":53569,\"name\":\"Beth Collins\"\
+        ,\"username\":\"bethcollins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"created_at\":\"2020-11-10T12:35:39.736Z\",\"cooked\":\"\\u003cdiv class=\\\
+        \"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\\
+        u003ctr\\u003e\\n\\u003ctd\\u003eimage\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eimage_width\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eimage_height\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e294\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003emeta_image\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/f8e683a9-twitter_wide_banner+%286%29.jpeg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f8e683a9-twitter_wide_banner+(6).jpeg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003emeta_copydoc\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://docs.google.com/document/d/19he9v3cr2cQkghdhlBJlykHmoyleThrx252_ytFwIh0/edit\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://docs.google.com/document/d/19he9v3cr2cQkghdhlBJlykHmoyleThrx252_ytFwIh0/edit\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003ebanner_class\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eform_id\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e3763\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eresource_url\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eprimary_cta\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the\
+        \ whitepaper\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eprimary_link\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003cspan\
+        \ class=\\\"hashtag\\\"\\u003e#the-form\\u003c/span\\u003e\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\\
+        u003e\\u003ch2\\u003eWhy is Ubuntu popular with top financial institutions?\\\
+        u003c/h2\\u003e\\n\\u003cp\\u003eUbuntu leads in security and performance\
+        \ on both public and hybrid clouds. It is the popular choice for developers\
+        \ at global financial institutions because of its versatility, reliability,\
+        \ freshness and ecosystem. From AI to System Z, Ubuntu is the fastest growing\
+        \ platform on the planet.\\u003c/p\\u003e\\n\\u003ch2\\u003eNeed for agility\\\
+        u003c/h2\\u003e\\n\\u003cp\\u003eFinancial institutions are increasingly pressed\
+        \ for agility and velocity to adapt to changing market conditions, increased\
+        \ customer expectations while satisfying regulatory and compliance requirements.\\\
+        u003c/p\\u003e\\n\\u003cp\\u003eCanonical helps financial institutions drive\
+        \ infrastructure efficiency and operational agility with multi-cloud, hybrid\
+        \ cloud and bare-metal solutions.\\u003c/p\\u003e\\n\\u003ch2\\u003eInnovate\
+        \ at speed while keeping costs under control\\u003c/h2\\u003e\\n\\u003cp\\\
+        u003eMore and more financial institutions are embracing a cloud-native approach\
+        \ to application development and deployment, helping them realise value around\
+        \ their key business priorities.\\u003c/p\\u003e\\n\\u003cp\\u003eCanonical\
+        \ delivers pure upstream Kubernetes tested across the widest range of clouds\
+        \ \u2014 from public clouds to private data centres, from bare metal to virtualised\
+        \ infrastructure allowing financial institutions to scale innovation at speed\
+        \ and drive down costs.\\u003c/p\\u003e\\n\\u003cp\\u003e\\u003ca href=\\\"\
+        https://ubuntu.com/contact-us\\\" rel=\\\"nofollow noopener\\\"\\u003eContact\
+        \ us\\u003c/a\\u003e to discuss how Canonical can help you realise business\
+        \ value from open source technology and help drive innovation at scale.\\\
+        u003c/p\\u003e\\n\\u003cp\\u003e\\u003cem\\u003eFinancial institutions for\
+        \ this analysis were ranked by total \\u003ca href=\\\"https://en.wikipedia.org/wiki/Assets\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003eassets\\u003c/a\\u003e as of March\
+        \ 31, 2020 per the Federal Financial Institutions Examination Council.\\u003c/em\\\
+        u003e\\u003c/p\\u003e\",\"post_number\":1,\"post_type\":1,\"updated_at\":\"\
+        2020-11-17T15:51:38.627Z\",\"reply_count\":0,\"reply_to_post_number\":null,\"\
+        quote_count\":0,\"incoming_link_count\":5,\"reads\":29,\"score\":30.6,\"yours\"\
+        :false,\"topic_id\":19304,\"topic_slug\":\"9-out-of-top-10-us-european-financial-institutions-use-ubuntu\"\
+        ,\"display_username\":\"Beth Collins\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":3,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":5},{\"url\":\"https://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\"\
+        ,\"clicks\":4},{\"url\":\"https://ubuntu.com/contact-us\",\"internal\":false,\"\
+        reflection\":false,\"title\":\"Contact Canonical | Ubuntu\",\"clicks\":1},{\"\
+        url\":\"https://assets.ubuntu.com/v1/f8e683a9-twitter_wide_banner+%286%29.jpeg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"f8e683a9-twitter_wide_banner+%286%29.jpeg\"\
+        ,\"clicks\":0},{\"url\":\"https://en.wikipedia.org/wiki/Assets\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://docs.google.com/document/d/19he9v3cr2cQkghdhlBJlykHmoyleThrx252_ytFwIh0/edit\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/engage-pages-and-takeovers/17229\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"Engage pages and Takeovers\"\
+        ,\"clicks\":0}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":true,\"admin\":false,\"staff\":true,\"user_id\":12532,\"hidden\"\
+        :false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[53569]},\"timeline_lookup\":[[1,8]],\"suggested_topics\":[{\"id\":17329,\"\
+        title\":\"Private cloud security Webinar\",\"fancy_title\":\"Private cloud\
+        \ security Webinar\",\"slug\":\"private-cloud-security-webinar\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T12:59:27.947Z\",\"last_posted_at\":\"2020-07-17T12:59:28.083Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:54:24.522Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":97,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17304,\"title\":\"Six reasons why developers choose Ubuntu Desktop\"\
+        ,\"fancy_title\":\"Six reasons why developers choose Ubuntu Desktop\",\"slug\"\
+        :\"six-reasons-why-developers-choose-ubuntu-desktop\",\"posts_count\":1,\"\
+        reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T12:13:22.072Z\",\"last_posted_at\":\"2020-07-17T12:13:22.202Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:24:52.027Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":142,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
+        id\":17317,\"title\":\"Establishing a software defined IoT business model\"\
+        ,\"fancy_title\":\"Establishing a software defined IoT business model\",\"\
+        slug\":\"establishing-a-software-defined-iot-business-model\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T12:38:10.138Z\",\"last_posted_at\":\"2020-07-17T12:38:10.264Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:38:10.264Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":138,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
+        id\":17318,\"title\":\"Securing IoT device data against physical access\"\
+        ,\"fancy_title\":\"Securing IoT device data against physical access\",\"slug\"\
+        :\"securing-iot-device-data-against-physical-access\",\"posts_count\":1,\"\
+        reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T12:42:26.503Z\",\"last_posted_at\":\"2020-07-17T12:42:26.689Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:42:26.689Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":133,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
+        id\":18162,\"title\":\"Transforming telco infrastructure: A virtual event\"\
+        ,\"fancy_title\":\"Transforming telco infrastructure: A virtual event\",\"\
+        slug\":\"transforming-telco-infrastructure-a-virtual-event\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-09-04T17:32:27.757Z\",\"last_posted_at\":\"2020-09-04T17:32:27.894Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-09-24T14:49:04.888Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":151,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":9642,\"\
+        username\":\"carkod\",\"name\":\"Carlos Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":19304,\"title\":\"9 out of top 10 US \\u0026 European\
+        \ financial institutions use Ubuntu\",\"fancy_title\":\"9 out of top 10 US\
+        \ \\u0026amp; European financial institutions use Ubuntu\",\"posts_count\"\
+        :1,\"created_at\":\"2020-11-10T12:35:39.581Z\",\"views\":126,\"reply_count\"\
+        :0,\"like_count\":0,\"last_posted_at\":\"2020-11-10T12:35:39.736Z\",\"visible\"\
+        :true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"archetype\"\
+        :\"regular\",\"slug\":\"9-out-of-top-10-us-european-financial-institutions-use-ubuntu\"\
+        ,\"category_id\":51,\"word_count\":283,\"deleted_at\":null,\"user_id\":12532,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\"\
+        :null,\"draft\":null,\"draft_key\":\"topic_19304\",\"draft_sequence\":null,\"\
+        unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":4,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth Collins\",\"\
+        avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":12532,\"\
+        username\":\"bethcollins\",\"name\":\"Beth Collins\",\"avatar_template\":\"\
+        /letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        },\"last_poster\":{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth\
+        \ Collins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        },\"links\":[{\"url\":\"https://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\"\
+        ,\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"\
+        clicks\":5,\"user_id\":12532,\"domain\":\"pages.ubuntu.com\",\"root_domain\"\
+        :\"ubuntu.com\"},{\"url\":\"https://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\"\
+        ,\"title\":\"1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\",\"internal\"\
+        :false,\"attachment\":false,\"reflection\":false,\"clicks\":4,\"user_id\"\
+        :12532,\"domain\":\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"\
+        url\":\"https://ubuntu.com/contact-us\",\"title\":\"Contact Canonical | Ubuntu\"\
+        ,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":12532,\"domain\":\"ubuntu.com\",\"root_domain\":\"ubuntu.com\"}]}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 22:48:15 GMT
+      Keep-Alive:
+      - timeout=5, max=99
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Cached:
+      - 'true'
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 2b44b91d-5198-4376-8668-2a9bc9ab5ffd
+      X-Runtime:
+      - '0.001964'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestDiscourseAPI.test_active_page_returns_adds_no_meta_with_preview_flag.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_active_page_returns_adds_no_meta_with_preview_flag.yaml
@@ -1,0 +1,2523 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/17229.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
+        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
+        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
+        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
+        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
+        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
+        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
+        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
+        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
+        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
+        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
+        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
+        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
+        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
+        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
+        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
+        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
+        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
+        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
+        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
+        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
+        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
+        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
+        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
+        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
+        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
+        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
+        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
+        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
+        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
+        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
+        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
+        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
+        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
+        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
+        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
+        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
+        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
+        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
+        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
+        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
+        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
+        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
+        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
+        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
+        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
+        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
+        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
+        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
+        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
+        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
+        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
+        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
+        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
+        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
+        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
+        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
+        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
+        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
+        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
+        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
+        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
+        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
+        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
+        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
+        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
+        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
+        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
+        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
+        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
+        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
+        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
+        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
+        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
+        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
+        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
+        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
+        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
+        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
+        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
+        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
+        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
+        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
+        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
+        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
+        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
+        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
+        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
+        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
+        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
+        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
+        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
+        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
+        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
+        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
+        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
+        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
+        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
+        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
+        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
+        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
+        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
+        \ MicroK8s, what it is and why you should use it. This event will also include\
+        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
+        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
+        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
+        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
+        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
+        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
+        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
+        \ initial deployment and reduce operational costs by outsourcing private cloud\
+        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
+        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
+        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
+        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
+        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
+        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
+        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
+        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
+        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
+        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
+        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
+        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
+        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
+        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
+        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
+        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
+        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
+        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
+        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
+        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
+        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
+        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
+        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
+        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
+        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
+        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
+        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
+        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
+        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
+        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
+        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
+        \ live-migration extensions for easier infrastructure deployments and more.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
+        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
+        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
+        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
+        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
+        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
+        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
+        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
+        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
+        \ Proxy overcomes challenges presented by restricted networks and management\
+        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
+        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
+        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
+        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
+        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
+        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
+        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
+        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
+        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
+        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
+        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
+        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
+        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
+        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
+        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
+        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
+        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
+        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
+        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
+        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
+        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
+        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
+        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
+        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
+        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
+        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
+        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
+        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
+        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
+        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
+        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
+        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
+        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
+        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
+        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
+        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
+        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
+        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
+        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
+        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
+        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
+        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
+        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
+        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
+        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
+        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
+        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
+        \ provides enterprises with real-time data processing, cost-effective security\
+        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
+        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
+        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
+        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
+        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
+        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
+        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
+        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
+        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
+        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
+        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
+        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
+        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
+        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
+        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
+        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
+        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
+        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
+        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
+        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
+        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
+        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
+        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
+        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
+        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
+        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
+        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
+        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
+        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
+        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
+        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
+        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
+        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
+        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
+        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
+        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
+        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
+        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
+        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
+        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
+        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
+        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Trilio and Canonical help organisations transition to new, maintainable\
+        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
+        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
+        \ on drones to replace human workers in potentially dangerous scenarios.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
+        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
+        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
+        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
+        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
+        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
+        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
+        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
+        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
+        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
+        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
+        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
+        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
+        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
+        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
+        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
+        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
+        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
+        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
+        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
+        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
+        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
+        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
+        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
+        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
+        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
+        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
+        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
+        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
+        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
+        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
+        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
+        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
+        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
+        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
+        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
+        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
+        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
+        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
+        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
+        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
+        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
+        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
+        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
+        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
+        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
+        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
+        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
+        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
+        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
+        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
+        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
+        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
+        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
+        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
+        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
+        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
+        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
+        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
+        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
+        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
+        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
+        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
+        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
+        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
+        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eA deep dive into securing against the threats of cyber attacks and data\
+        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
+        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
+        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
+        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
+        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
+        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
+        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
+        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
+        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
+        \ for the ultimate edge device including development, extensibility, risk\
+        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
+        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
+        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
+        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
+        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
+        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Apellix has designed revolutionary software to solve industrial IoT\
+        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
+        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
+        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
+        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
+        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ about Ubuntu CIS and FIPS certified components to enable operating under\
+        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
+        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
+        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
+        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
+        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
+        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
+        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
+        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
+        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
+        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
+        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
+        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
+        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
+        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
+        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
+        :1,\"updated_at\":\"2020-11-18T22:50:16.694Z\",\"reply_count\":0,\"reply_to_post_number\"\
+        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
+        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
+        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":27,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
+        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
+        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
+        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
+        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
+        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
+        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
+        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
+        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
+        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
+        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
+        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
+        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
+        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
+        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
+        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
+        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
+        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
+        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
+        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
+        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
+        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
+        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
+        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
+        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
+        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
+        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
+        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
+        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
+        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
+        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
+        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
+        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
+        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
+        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
+        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
+        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
+        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
+        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
+        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
+        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
+        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
+        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
+        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
+        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
+        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
+        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
+        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
+        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
+        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
+        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
+        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
+        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
+        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
+        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
+        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
+        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
+        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
+        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
+        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
+        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
+        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
+        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
+        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
+        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
+        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
+        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
+        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
+        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
+        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
+        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
+        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
+        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
+        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
+        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
+        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
+        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
+        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
+        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
+        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
+        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
+        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
+        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
+        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
+        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
+        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
+        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
+        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
+        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
+        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
+        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
+        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
+        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
+        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
+        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
+        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
+        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
+        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
+        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
+        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
+        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
+        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
+        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
+        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
+        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
+        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
+        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
+        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
+        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
+        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
+        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
+        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
+        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
+        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
+        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
+        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
+        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
+        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
+        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
+        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
+        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
+        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
+        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
+        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
+        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
+        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
+        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
+        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
+        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
+        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
+        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
+        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
+        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
+        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[48547]},\"timeline_lookup\":[[1,127]],\"suggested_topics\":[{\"id\":17333,\"\
+        title\":\"Key considerations when choosing a robot\u2019s operating system\"\
+        ,\"fancy_title\":\"Key considerations when choosing a robot\u2019s operating\
+        \ system\",\"slug\":\"key-considerations-when-choosing-a-robot-s-operating-system\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T13:04:41.034Z\",\"last_posted_at\":\"2020-07-17T13:04:41.164Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T13:04:41.164Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":127,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17335,\"title\":\"Optimising IoT bandwidth with delta updates\"\
+        ,\"fancy_title\":\"Optimising IoT bandwidth with delta updates\",\"slug\"\
+        :\"optimising-iot-bandwidth-with-delta-updates\",\"posts_count\":1,\"reply_count\"\
+        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-17T13:20:39.048Z\"\
+        ,\"last_posted_at\":\"2020-07-17T13:20:39.191Z\",\"bumped\":true,\"bumped_at\"\
+        :\"2020-07-17T13:20:39.191Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
+        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
+        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
+        :0,\"views\":131,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
+        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
+        \ Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"username\":\"owenrm\"\
+        ,\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17311,\"title\":\"Fing serves 30,000 customers with a secure,\
+        \ future-proof IoT device\",\"fancy_title\":\"Fing serves 30,000 customers\
+        \ with a secure, future-proof IoT device\",\"slug\":\"fing-serves-30-000-customers-with-a-secure-future-proof-iot-device\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T12:34:18.300Z\",\"last_posted_at\":\"2020-07-17T12:34:18.423Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:34:18.423Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":132,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
+        id\":17326,\"title\":\"NFV and SDN on OpenStack for network operators\",\"\
+        fancy_title\":\"NFV and SDN on OpenStack for network operators\",\"slug\"\
+        :\"nfv-and-sdn-on-openstack-for-network-operators\",\"posts_count\":1,\"reply_count\"\
+        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-17T12:57:29.021Z\"\
+        ,\"last_posted_at\":\"2020-07-17T12:57:29.123Z\",\"bumped\":true,\"bumped_at\"\
+        :\"2020-09-11T10:41:02.136Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
+        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
+        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
+        :0,\"views\":135,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
+        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
+        \ Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"username\":\"owenrm\"\
+        ,\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17397,\"title\":\"Scaling on Azure with Ubuntu Pro\",\"fancy_title\"\
+        :\"Scaling on Azure with Ubuntu Pro\",\"slug\":\"scaling-on-azure-with-ubuntu-pro\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:17:03.758Z\",\"last_posted_at\":\"2020-07-17T16:17:03.924Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:17:03.924Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":124,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
+        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
+        :\"2020-07-14T09:57:15.561Z\",\"views\":345,\"reply_count\":0,\"like_count\"\
+        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
+        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
+        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
+        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":227,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
+        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
+        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
+        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
+        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
+        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
+        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
+        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
+        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
+        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
+        :\"ubuntu.com\"}]}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 23:00:03 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Cached:
+      - 'true'
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 2b08db93-e654-4693-8175-3ef827633cf6
+      X-Runtime:
+      - '0.011345'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/19304.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":53569,\"name\":\"Beth Collins\"\
+        ,\"username\":\"bethcollins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"created_at\":\"2020-11-10T12:35:39.736Z\",\"cooked\":\"\\u003cdiv class=\\\
+        \"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\\
+        u003ctr\\u003e\\n\\u003ctd\\u003eimage\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eimage_width\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eimage_height\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e294\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003emeta_image\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/f8e683a9-twitter_wide_banner+%286%29.jpeg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f8e683a9-twitter_wide_banner+(6).jpeg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003emeta_copydoc\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://docs.google.com/document/d/19he9v3cr2cQkghdhlBJlykHmoyleThrx252_ytFwIh0/edit\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://docs.google.com/document/d/19he9v3cr2cQkghdhlBJlykHmoyleThrx252_ytFwIh0/edit\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003ebanner_class\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eform_id\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e3763\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eresource_url\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eprimary_cta\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the\
+        \ whitepaper\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eprimary_link\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003cspan\
+        \ class=\\\"hashtag\\\"\\u003e#the-form\\u003c/span\\u003e\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\\
+        u003e\\u003ch2\\u003eWhy is Ubuntu popular with top financial institutions?\\\
+        u003c/h2\\u003e\\n\\u003cp\\u003eUbuntu leads in security and performance\
+        \ on both public and hybrid clouds. It is the popular choice for developers\
+        \ at global financial institutions because of its versatility, reliability,\
+        \ freshness and ecosystem. From AI to System Z, Ubuntu is the fastest growing\
+        \ platform on the planet.\\u003c/p\\u003e\\n\\u003ch2\\u003eNeed for agility\\\
+        u003c/h2\\u003e\\n\\u003cp\\u003eFinancial institutions are increasingly pressed\
+        \ for agility and velocity to adapt to changing market conditions, increased\
+        \ customer expectations while satisfying regulatory and compliance requirements.\\\
+        u003c/p\\u003e\\n\\u003cp\\u003eCanonical helps financial institutions drive\
+        \ infrastructure efficiency and operational agility with multi-cloud, hybrid\
+        \ cloud and bare-metal solutions.\\u003c/p\\u003e\\n\\u003ch2\\u003eInnovate\
+        \ at speed while keeping costs under control\\u003c/h2\\u003e\\n\\u003cp\\\
+        u003eMore and more financial institutions are embracing a cloud-native approach\
+        \ to application development and deployment, helping them realise value around\
+        \ their key business priorities.\\u003c/p\\u003e\\n\\u003cp\\u003eCanonical\
+        \ delivers pure upstream Kubernetes tested across the widest range of clouds\
+        \ \u2014 from public clouds to private data centres, from bare metal to virtualised\
+        \ infrastructure allowing financial institutions to scale innovation at speed\
+        \ and drive down costs.\\u003c/p\\u003e\\n\\u003cp\\u003e\\u003ca href=\\\"\
+        https://ubuntu.com/contact-us\\\" rel=\\\"nofollow noopener\\\"\\u003eContact\
+        \ us\\u003c/a\\u003e to discuss how Canonical can help you realise business\
+        \ value from open source technology and help drive innovation at scale.\\\
+        u003c/p\\u003e\\n\\u003cp\\u003e\\u003cem\\u003eFinancial institutions for\
+        \ this analysis were ranked by total \\u003ca href=\\\"https://en.wikipedia.org/wiki/Assets\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003eassets\\u003c/a\\u003e as of March\
+        \ 31, 2020 per the Federal Financial Institutions Examination Council.\\u003c/em\\\
+        u003e\\u003c/p\\u003e\",\"post_number\":1,\"post_type\":1,\"updated_at\":\"\
+        2020-11-17T15:51:38.627Z\",\"reply_count\":0,\"reply_to_post_number\":null,\"\
+        quote_count\":0,\"incoming_link_count\":5,\"reads\":29,\"score\":30.6,\"yours\"\
+        :false,\"topic_id\":19304,\"topic_slug\":\"9-out-of-top-10-us-european-financial-institutions-use-ubuntu\"\
+        ,\"display_username\":\"Beth Collins\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":3,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":5},{\"url\":\"https://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\"\
+        ,\"clicks\":4},{\"url\":\"https://ubuntu.com/contact-us\",\"internal\":false,\"\
+        reflection\":false,\"title\":\"Contact Canonical | Ubuntu\",\"clicks\":1},{\"\
+        url\":\"https://assets.ubuntu.com/v1/f8e683a9-twitter_wide_banner+%286%29.jpeg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"f8e683a9-twitter_wide_banner+%286%29.jpeg\"\
+        ,\"clicks\":0},{\"url\":\"https://en.wikipedia.org/wiki/Assets\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://docs.google.com/document/d/19he9v3cr2cQkghdhlBJlykHmoyleThrx252_ytFwIh0/edit\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/engage-pages-and-takeovers/17229\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"Engage pages and Takeovers\"\
+        ,\"clicks\":0}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":true,\"admin\":false,\"staff\":true,\"user_id\":12532,\"hidden\"\
+        :false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[53569]},\"timeline_lookup\":[[1,8]],\"suggested_topics\":[{\"id\":17313,\"\
+        title\":\"Future-proofing Fingbox, the IoT home network monitoring device\"\
+        ,\"fancy_title\":\"Future-proofing Fingbox, the IoT home network monitoring\
+        \ device\",\"slug\":\"future-proofing-fingbox-the-iot-home-network-monitoring-device\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T12:35:42.155Z\",\"last_posted_at\":\"2020-07-17T12:35:42.279Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:35:42.279Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":117,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
+        id\":17340,\"title\":\"Securing the enterprise: how Ubuntu is at the forefront\
+        \ of security and compliance\",\"fancy_title\":\"Securing the enterprise:\
+        \ how Ubuntu is at the forefront of security and compliance\",\"slug\":\"\
+        securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T13:25:08.424Z\",\"last_posted_at\":\"2020-07-17T13:25:08.580Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T13:25:08.580Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":123,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17288,\"title\":\"Rocket.Chat communication platform enables\
+        \ simplicity through snaps\",\"fancy_title\":\"Rocket.Chat communication platform\
+        \ enables simplicity through snaps\",\"slug\":\"rocket-chat-communication-platform-enables-simplicity-through-snaps\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T10:38:20.969Z\",\"last_posted_at\":\"2020-07-17T10:38:21.101Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:38:21.101Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":121,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17281,\"title\":\"Cinergy makes significant digital signage saving\
+        \ with Screenly Pro and Ubuntu Core\",\"fancy_title\":\"Cinergy makes significant\
+        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"slug\":\"cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T10:33:27.119Z\",\"last_posted_at\":\"2020-07-17T10:33:27.262Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:33:27.262Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":119,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17341,\"title\":\"Ubuntu Core and Kura: A framework for IoT gateways\"\
+        ,\"fancy_title\":\"Ubuntu Core and Kura: A framework for IoT gateways\",\"\
+        slug\":\"ubuntu-core-and-kura-a-framework-for-iot-gateways\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T13:26:46.278Z\",\"last_posted_at\":\"2020-07-17T13:26:46.401Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T13:26:46.401Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":131,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":19304,\"title\":\"9 out of top 10 US \\u0026 European\
+        \ financial institutions use Ubuntu\",\"fancy_title\":\"9 out of top 10 US\
+        \ \\u0026amp; European financial institutions use Ubuntu\",\"posts_count\"\
+        :1,\"created_at\":\"2020-11-10T12:35:39.581Z\",\"views\":126,\"reply_count\"\
+        :0,\"like_count\":0,\"last_posted_at\":\"2020-11-10T12:35:39.736Z\",\"visible\"\
+        :true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"archetype\"\
+        :\"regular\",\"slug\":\"9-out-of-top-10-us-european-financial-institutions-use-ubuntu\"\
+        ,\"category_id\":51,\"word_count\":283,\"deleted_at\":null,\"user_id\":12532,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\"\
+        :null,\"draft\":null,\"draft_key\":\"topic_19304\",\"draft_sequence\":null,\"\
+        unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":4,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth Collins\",\"\
+        avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":12532,\"\
+        username\":\"bethcollins\",\"name\":\"Beth Collins\",\"avatar_template\":\"\
+        /letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        },\"last_poster\":{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth\
+        \ Collins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        },\"links\":[{\"url\":\"https://pages.ubuntu.com/rs/066-EOV-335/images/10558_Advisory_BW_Canonical.pdf\"\
+        ,\"title\":null,\"internal\":false,\"attachment\":false,\"reflection\":false,\"\
+        clicks\":5,\"user_id\":12532,\"domain\":\"pages.ubuntu.com\",\"root_domain\"\
+        :\"ubuntu.com\"},{\"url\":\"https://assets.ubuntu.com/v1/1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\"\
+        ,\"title\":\"1e4e76d7-FinancialServicesPage-MultiCloud_2020_wht.svg\",\"internal\"\
+        :false,\"attachment\":false,\"reflection\":false,\"clicks\":4,\"user_id\"\
+        :12532,\"domain\":\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"\
+        url\":\"https://ubuntu.com/contact-us\",\"title\":\"Contact Canonical | Ubuntu\"\
+        ,\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":12532,\"domain\":\"ubuntu.com\",\"root_domain\":\"ubuntu.com\"}]}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 23:00:04 GMT
+      Keep-Alive:
+      - timeout=5, max=99
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 23cea626-75a8-4253-acaa-cb3e8051eb14
+      X-Runtime:
+      - '0.127393'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestDiscourseAPI.test_inactive_page_returns_302.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_inactive_page_returns_302.yaml
@@ -1,0 +1,2505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/17229.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
+        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
+        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
+        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
+        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
+        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
+        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
+        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
+        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
+        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
+        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
+        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
+        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
+        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
+        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
+        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
+        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
+        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
+        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
+        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
+        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
+        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
+        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
+        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
+        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
+        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
+        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
+        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
+        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
+        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
+        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
+        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
+        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
+        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
+        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
+        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
+        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
+        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
+        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
+        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
+        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
+        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
+        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
+        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
+        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
+        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
+        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
+        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
+        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
+        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
+        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
+        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
+        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
+        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
+        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
+        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
+        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
+        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
+        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
+        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
+        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
+        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
+        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
+        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
+        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
+        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
+        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
+        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
+        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
+        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
+        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
+        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
+        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
+        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
+        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
+        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
+        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
+        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
+        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
+        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
+        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
+        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
+        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
+        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
+        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
+        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
+        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
+        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
+        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
+        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
+        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
+        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
+        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
+        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
+        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
+        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
+        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
+        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
+        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
+        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
+        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
+        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
+        \ MicroK8s, what it is and why you should use it. This event will also include\
+        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
+        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
+        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
+        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
+        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
+        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
+        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
+        \ initial deployment and reduce operational costs by outsourcing private cloud\
+        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
+        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
+        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
+        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
+        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
+        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
+        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
+        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
+        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
+        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
+        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
+        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
+        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
+        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
+        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
+        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
+        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
+        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
+        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
+        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
+        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
+        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
+        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
+        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
+        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
+        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
+        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
+        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
+        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
+        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
+        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
+        \ live-migration extensions for easier infrastructure deployments and more.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
+        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
+        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
+        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
+        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
+        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
+        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
+        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
+        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
+        \ Proxy overcomes challenges presented by restricted networks and management\
+        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
+        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
+        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
+        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
+        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
+        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
+        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
+        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
+        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
+        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
+        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
+        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
+        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
+        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
+        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
+        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
+        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
+        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
+        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
+        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
+        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
+        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
+        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
+        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
+        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
+        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
+        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
+        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
+        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
+        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
+        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
+        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
+        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
+        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
+        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
+        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
+        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
+        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
+        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
+        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
+        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
+        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
+        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
+        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
+        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
+        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
+        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
+        \ provides enterprises with real-time data processing, cost-effective security\
+        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
+        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
+        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
+        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
+        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
+        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
+        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
+        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
+        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
+        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
+        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
+        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
+        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
+        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
+        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
+        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
+        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
+        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
+        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
+        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
+        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
+        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
+        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
+        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
+        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
+        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
+        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
+        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
+        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
+        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
+        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
+        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
+        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
+        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
+        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
+        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
+        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
+        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
+        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
+        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
+        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
+        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Trilio and Canonical help organisations transition to new, maintainable\
+        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
+        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
+        \ on drones to replace human workers in potentially dangerous scenarios.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
+        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
+        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
+        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
+        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
+        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
+        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
+        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
+        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
+        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
+        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
+        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
+        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
+        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
+        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
+        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
+        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
+        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
+        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
+        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
+        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
+        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
+        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
+        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
+        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
+        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
+        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
+        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
+        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
+        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
+        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
+        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
+        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
+        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
+        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
+        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
+        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
+        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
+        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
+        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
+        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
+        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
+        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
+        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
+        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
+        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
+        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
+        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
+        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
+        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
+        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
+        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
+        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
+        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
+        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
+        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
+        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
+        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
+        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
+        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
+        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
+        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
+        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
+        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
+        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
+        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eA deep dive into securing against the threats of cyber attacks and data\
+        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
+        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
+        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
+        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
+        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
+        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
+        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
+        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
+        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
+        \ for the ultimate edge device including development, extensibility, risk\
+        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
+        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
+        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
+        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
+        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
+        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Apellix has designed revolutionary software to solve industrial IoT\
+        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
+        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
+        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
+        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
+        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ about Ubuntu CIS and FIPS certified components to enable operating under\
+        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
+        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
+        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
+        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
+        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
+        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
+        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
+        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
+        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
+        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
+        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
+        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
+        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
+        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
+        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
+        :1,\"updated_at\":\"2020-11-18T12:27:45.618Z\",\"reply_count\":0,\"reply_to_post_number\"\
+        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
+        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
+        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":26,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
+        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
+        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
+        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
+        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
+        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
+        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
+        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
+        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
+        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
+        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
+        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
+        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
+        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
+        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
+        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
+        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
+        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
+        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
+        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
+        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
+        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
+        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
+        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
+        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
+        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
+        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
+        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
+        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
+        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
+        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
+        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
+        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
+        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
+        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
+        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
+        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
+        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
+        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
+        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
+        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
+        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
+        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
+        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
+        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
+        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
+        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
+        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
+        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
+        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
+        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
+        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
+        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
+        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
+        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
+        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
+        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
+        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
+        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
+        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
+        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
+        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
+        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
+        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
+        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
+        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
+        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
+        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
+        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
+        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
+        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
+        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
+        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
+        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
+        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
+        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
+        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
+        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
+        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
+        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
+        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
+        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
+        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
+        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
+        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
+        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
+        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
+        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
+        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
+        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
+        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
+        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
+        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
+        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
+        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
+        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
+        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
+        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
+        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
+        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
+        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
+        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
+        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
+        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
+        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
+        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
+        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
+        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
+        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
+        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
+        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
+        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
+        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
+        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
+        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
+        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
+        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
+        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
+        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
+        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
+        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
+        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
+        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
+        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
+        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
+        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
+        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
+        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
+        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
+        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
+        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
+        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
+        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
+        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[48547]},\"timeline_lookup\":[[1,127]],\"suggested_topics\":[{\"id\":17389,\"\
+        title\":\"Leveraging open source with Ubuntu Pro on Azure\",\"fancy_title\"\
+        :\"Leveraging open source with Ubuntu Pro on Azure\",\"slug\":\"leveraging-open-source-with-ubuntu-pro-on-azure\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:08:24.599Z\",\"last_posted_at\":\"2020-07-17T16:08:24.765Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:08:24.765Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":132,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17412,\"title\":\"Canonical int\xE8gre containerd \xE0 Ubuntu\
+        \ Kubernetes\",\"fancy_title\":\"Canonical int\xE8gre containerd \xE0 Ubuntu\
+        \ Kubernetes\",\"slug\":\"canonical-integre-containerd-a-ubuntu-kubernetes\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:33:36.646Z\",\"last_posted_at\":\"2020-07-17T16:33:36.809Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:33:36.809Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":47,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17384,\"title\":\"OpenStack deployment guide\",\"fancy_title\"\
+        :\"OpenStack deployment guide\",\"slug\":\"openstack-deployment-guide\",\"\
+        posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:04:01.257Z\",\"last_posted_at\":\"2020-07-17T16:04:01.377Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-08-04T12:39:29.646Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":152,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17362,\"title\":\"Linux security with Ubuntu\",\"fancy_title\"\
+        :\"Linux security with Ubuntu\",\"slug\":\"linux-security-with-ubuntu\",\"\
+        posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T14:35:56.497Z\",\"last_posted_at\":\"2020-07-17T14:35:56.616Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T14:35:56.616Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":135,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17418,\"title\":\"Installez et mettez OpenStack \xE0 l'\xE9chelle\
+        \ en toute simplicit\xE9\",\"fancy_title\":\"Installez et mettez OpenStack\
+        \ \xE0 l\\u0026rsquo;\xE9chelle en toute simplicit\xE9\",\"slug\":\"installez-et-mettez-openstack-a-lechelle-en-toute-simplicite\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:42:33.473Z\",\"last_posted_at\":\"2020-07-17T16:42:33.705Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:42:33.705Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":134,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
+        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
+        :\"2020-07-14T09:57:15.561Z\",\"views\":345,\"reply_count\":0,\"like_count\"\
+        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
+        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
+        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
+        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":221,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
+        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
+        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
+        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
+        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
+        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
+        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
+        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
+        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
+        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
+        :\"ubuntu.com\"}]}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 22:48:15 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Cached:
+      - 'true'
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 934534c4-70a4-4744-8649-2857ac5a05b0
+      X-Runtime:
+      - '0.002628'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/19381.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":53739,\"name\":\"Beth Collins\"\
+        ,\"username\":\"bethcollins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"created_at\":\"2020-11-17T09:27:47.898Z\",\"cooked\":\"\\u003cdiv class=\\\
+        \"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\\
+        u003ctr\\u003e\\n\\u003ctd\\u003eimage\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eimage_width\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eimage_height\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003emeta_image\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/178bfce7-twitter_wide_banner+%2813%29.jpeg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/178bfce7-twitter_wide_banner+(13).jpeg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003emeta_copydoc\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://docs.google.com/document/d/1I4H1gdSa4RpiRHn3ZcG8QwcKY4KrBKpJ9ZpbYAyBipY/edit\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://docs.google.com/document/d/1I4H1gdSa4RpiRHn3ZcG8QwcKY4KrBKpJ9ZpbYAyBipY/edit\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003ebanner_class\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eform_id\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e3734\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eresource_url\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://pages.ubuntu.com/rs/066-EOV-335/images/IT_Accelerate_Kubernetes_enterprise_16.11.20.pdf\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://pages.ubuntu.com/rs/066-EOV-335/images/IT_Accelerate_Kubernetes_enterprise_16.11.20.pdf\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eprimary_cta\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eprimary_link\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003cspan class=\\\"hashtag\\\"\\u003e#the-form\\\
+        u003c/span\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\\
+        n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003cp\\u003eMan mano che l\u2019\
+        adozione di Kubernetes si estende dai primi utilizzatori alle imprese pi\xF9\
+        \ lente, molte aziende stanno scoprendo che, mentre i container e Kubernetes\
+        \ offrono vantaggi in termini di sviluppo, velocit\xE0, agilit\xE0 e gestione\
+        \ dei costi, essi creano anche una nuova serie di sfide da superare.\\u003c/p\\\
+        u003e\\n\\u003cp\\u003eMentre ci sono aspetti comuni nei tipi di sfide che\
+        \ le imprese devono affrontare con Kubernetes, non c\u2019\xE8 un vero e proprio\
+        \ modo per gestirle, ma piuttosto una serie di potenziali approcci, ognuno\
+        \ con i propri vantaggi e svantaggi.\\u003c/p\\u003e\\n\\u003cp\\u003eIn questo\
+        \ white paper e webinar esamineremo le motivazioni che la maggior parte delle\
+        \ imprese hanno quando adottano Kubernetes, gli approcci disponibili e le\
+        \ valutazioni da tenere in considerazione a seconda delle dimensioni dell\u2019\
+        impresa, della sua sofisticazione tecnica, dell\u2019infrastruttura attuale\
+        \ e del suo budget.\\u003c/p\\u003e\\n\\u003cp\\u003eScaricate oggi per:\\\
+        u003c/p\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eScoprire\
+        \ i principali vantaggi di Kubernetes per l\u2019impresa e perch\xE9 ha conquistato\
+        \ lo spazio di containerizzazione.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\n\\\
+        u003cli\\u003e\\n\\u003cp\\u003eScoprire le sfide pi\xF9 comuni che le imprese\
+        \ devono affrontare nel processo di adozione di Kubernetes.\\u003c/p\\u003e\\\
+        n\\u003c/li\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eOttenere un confronto\
+        \ approfondito delle soluzioni Kubernetes pi\xF9 importanti sul mercato, tra\
+        \ cui: Vanilla, PaaS, distribuzione di Kubernetes in cloud pubblico, gestito,\
+        \ e piattaforma Enterprise Kubernetes.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\\
+        n\\u003c/ul\\u003e\\n\\u003cp\\u003eCinque strategie per accelerare l\u2019\
+        implementazione di Kubernetes nell\u2019impresa\\u003c/p\\u003e\",\"post_number\"\
+        :1,\"post_type\":1,\"updated_at\":\"2020-11-17T09:27:47.898Z\",\"reply_count\"\
+        :0,\"reply_to_post_number\":null,\"quote_count\":0,\"incoming_link_count\"\
+        :5,\"reads\":9,\"score\":26.4,\"yours\":false,\"topic_id\":19381,\"topic_slug\"\
+        :\"cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa\"\
+        ,\"display_username\":\"Beth Collins\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":1,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://pages.ubuntu.com/rs/066-EOV-335/images/IT_Accelerate_Kubernetes_enterprise_16.11.20.pdf\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://docs.google.com/document/d/1I4H1gdSa4RpiRHn3ZcG8QwcKY4KrBKpJ9ZpbYAyBipY/edit\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/178bfce7-twitter_wide_banner+%2813%29.jpeg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"178bfce7-twitter_wide_banner+%2813%29.jpeg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/engage-pages-and-takeovers/17229\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"Engage pages and Takeovers\"\
+        ,\"clicks\":0}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":true,\"admin\":false,\"staff\":true,\"user_id\":12532,\"hidden\"\
+        :false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[53739]},\"timeline_lookup\":[[1,1]],\"suggested_topics\":[{\"id\":17338,\"\
+        title\":\"Carrier Cloudification: What every telecom executive needs to know\"\
+        ,\"fancy_title\":\"Carrier Cloudification: What every telecom executive needs\
+        \ to know\",\"slug\":\"carrier-cloudification-what-every-telecom-executive-needs-to-know\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T13:23:55.609Z\",\"last_posted_at\":\"2020-07-17T13:23:55.743Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T13:23:55.743Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":92,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17388,\"title\":\"Streamlined Kubernetes, from Cloud to Edge\"\
+        ,\"fancy_title\":\"Streamlined Kubernetes, from Cloud to Edge\",\"slug\":\"\
+        streamlined-kubernetes-from-cloud-to-edge\",\"posts_count\":1,\"reply_count\"\
+        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-17T16:07:23.946Z\"\
+        ,\"last_posted_at\":\"2020-07-17T16:07:24.077Z\",\"bumped\":true,\"bumped_at\"\
+        :\"2020-07-17T16:07:24.077Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
+        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
+        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
+        :0,\"views\":131,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
+        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
+        \ Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"username\":\"owenrm\"\
+        ,\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17286,\"title\":\"ITstrategen keeps legacy applications secure\
+        \ with Extended Security Maintenance\",\"fancy_title\":\"ITstrategen keeps\
+        \ legacy applications secure with Extended Security Maintenance\",\"slug\"\
+        :\"itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T10:37:28.947Z\",\"last_posted_at\":\"2020-07-17T10:37:29.099Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:37:29.099Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":135,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17281,\"title\":\"Cinergy makes significant digital signage saving\
+        \ with Screenly Pro and Ubuntu Core\",\"fancy_title\":\"Cinergy makes significant\
+        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"slug\":\"cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T10:33:27.119Z\",\"last_posted_at\":\"2020-07-17T10:33:27.262Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:33:27.262Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":119,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17390,\"title\":\"Secure IoT device management\",\"fancy_title\"\
+        :\"Secure IoT device management\",\"slug\":\"secure-iot-device-management\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:09:14.101Z\",\"last_posted_at\":\"2020-07-17T16:09:14.237Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:09:14.237Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":122,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":19381,\"title\":\"Cinque strategie per accelerare\
+        \ l'implementazione di Kubernetes nell'impresa\",\"fancy_title\":\"Cinque\
+        \ strategie per accelerare l\\u0026rsquo;implementazione di Kubernetes nell\\\
+        u0026rsquo;impresa\",\"posts_count\":1,\"created_at\":\"2020-11-17T09:27:47.699Z\"\
+        ,\"views\":36,\"reply_count\":0,\"like_count\":0,\"last_posted_at\":\"2020-11-17T09:27:47.898Z\"\
+        ,\"visible\":true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"\
+        archetype\":\"regular\",\"slug\":\"cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa\"\
+        ,\"category_id\":51,\"word_count\":269,\"deleted_at\":null,\"user_id\":12532,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\"\
+        :null,\"draft\":null,\"draft_key\":\"topic_19381\",\"draft_sequence\":null,\"\
+        unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":6,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth Collins\",\"\
+        avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":12532,\"\
+        username\":\"bethcollins\",\"name\":\"Beth Collins\",\"avatar_template\":\"\
+        /letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        },\"last_poster\":{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth\
+        \ Collins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 22:48:16 GMT
+      Keep-Alive:
+      - timeout=5, max=99
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Cached:
+      - 'true'
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - cbf94037-5268-458e-98d2-41637426cfc3
+      X-Runtime:
+      - '0.007024'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestDiscourseAPI.test_inactive_page_returns_page_with_preview_flag.yaml
+++ b/tests/cassettes/TestDiscourseAPI.test_inactive_page_returns_page_with_preview_flag.yaml
@@ -1,0 +1,2502 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/17229.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
+        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
+        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
+        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
+        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
+        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
+        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
+        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
+        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
+        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
+        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
+        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
+        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
+        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
+        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
+        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
+        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
+        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
+        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
+        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
+        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
+        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
+        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
+        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
+        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
+        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
+        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
+        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
+        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
+        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
+        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
+        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
+        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
+        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
+        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
+        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
+        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
+        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
+        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
+        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
+        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
+        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
+        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
+        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
+        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
+        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
+        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
+        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
+        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
+        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
+        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
+        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
+        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
+        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
+        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
+        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
+        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
+        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
+        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
+        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
+        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
+        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
+        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
+        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
+        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
+        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
+        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
+        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
+        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
+        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
+        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
+        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
+        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
+        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
+        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
+        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
+        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
+        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
+        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
+        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
+        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
+        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
+        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
+        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
+        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
+        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
+        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
+        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
+        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
+        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
+        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
+        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
+        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
+        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
+        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
+        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
+        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
+        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
+        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
+        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
+        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
+        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
+        \ MicroK8s, what it is and why you should use it. This event will also include\
+        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
+        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
+        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
+        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
+        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
+        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
+        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
+        \ initial deployment and reduce operational costs by outsourcing private cloud\
+        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
+        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
+        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
+        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
+        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
+        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
+        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
+        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
+        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
+        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
+        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
+        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
+        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
+        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
+        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
+        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
+        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
+        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
+        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
+        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
+        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
+        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
+        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
+        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
+        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
+        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
+        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
+        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
+        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
+        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
+        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
+        \ live-migration extensions for easier infrastructure deployments and more.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
+        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
+        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
+        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
+        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
+        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
+        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
+        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
+        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
+        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
+        \ Proxy overcomes challenges presented by restricted networks and management\
+        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
+        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
+        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
+        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
+        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
+        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
+        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
+        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
+        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
+        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
+        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
+        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
+        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
+        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
+        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
+        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
+        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
+        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
+        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
+        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
+        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
+        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
+        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
+        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
+        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
+        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
+        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
+        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
+        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
+        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
+        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
+        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
+        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
+        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
+        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
+        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
+        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
+        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
+        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
+        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
+        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
+        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
+        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
+        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
+        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
+        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
+        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
+        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
+        \ provides enterprises with real-time data processing, cost-effective security\
+        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
+        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
+        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
+        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
+        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
+        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
+        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
+        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
+        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
+        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
+        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
+        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
+        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
+        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
+        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
+        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
+        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
+        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
+        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
+        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
+        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
+        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
+        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
+        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
+        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
+        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
+        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
+        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
+        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
+        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
+        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
+        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
+        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
+        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
+        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
+        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
+        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
+        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
+        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
+        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
+        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
+        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
+        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
+        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Trilio and Canonical help organisations transition to new, maintainable\
+        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
+        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
+        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
+        \ on drones to replace human workers in potentially dangerous scenarios.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
+        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
+        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
+        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
+        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
+        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
+        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
+        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
+        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
+        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
+        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
+        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
+        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
+        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
+        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
+        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
+        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
+        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
+        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
+        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
+        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
+        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
+        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
+        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
+        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
+        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
+        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
+        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
+        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
+        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
+        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
+        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
+        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
+        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
+        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
+        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
+        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
+        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
+        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
+        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
+        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
+        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
+        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
+        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
+        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
+        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
+        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
+        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
+        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
+        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
+        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
+        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
+        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
+        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
+        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
+        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
+        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
+        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
+        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
+        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
+        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
+        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
+        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
+        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
+        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
+        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
+        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
+        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
+        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
+        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
+        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
+        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
+        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
+        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eA deep dive into securing against the threats of cyber attacks and data\
+        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
+        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
+        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
+        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
+        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
+        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
+        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
+        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
+        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
+        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
+        \ for the ultimate edge device including development, extensibility, risk\
+        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
+        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
+        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
+        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
+        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
+        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
+        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
+        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
+        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
+        \ how Apellix has designed revolutionary software to solve industrial IoT\
+        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
+        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
+        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
+        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
+        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
+        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ about Ubuntu CIS and FIPS certified components to enable operating under\
+        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
+        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
+        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
+        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
+        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
+        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
+        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
+        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
+        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
+        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
+        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
+        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
+        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
+        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
+        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
+        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
+        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
+        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
+        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
+        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
+        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
+        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
+        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
+        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
+        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
+        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
+        :1,\"updated_at\":\"2020-11-18T22:50:16.694Z\",\"reply_count\":0,\"reply_to_post_number\"\
+        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
+        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
+        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":27,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
+        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
+        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
+        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
+        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
+        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
+        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
+        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
+        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
+        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
+        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
+        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
+        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
+        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
+        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
+        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
+        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
+        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
+        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
+        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
+        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
+        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
+        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
+        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
+        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
+        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
+        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
+        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
+        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
+        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
+        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
+        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
+        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
+        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
+        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
+        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
+        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
+        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
+        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
+        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
+        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
+        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
+        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
+        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
+        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
+        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
+        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
+        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
+        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
+        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
+        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
+        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
+        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
+        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
+        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
+        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
+        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
+        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
+        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
+        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
+        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
+        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
+        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
+        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
+        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
+        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
+        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
+        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
+        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
+        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
+        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
+        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
+        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
+        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
+        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
+        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
+        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
+        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
+        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
+        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
+        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
+        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
+        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
+        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
+        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
+        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
+        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
+        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
+        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
+        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
+        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
+        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
+        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
+        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
+        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
+        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
+        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
+        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
+        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
+        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
+        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
+        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
+        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
+        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
+        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
+        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
+        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
+        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
+        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
+        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
+        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
+        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
+        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
+        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
+        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
+        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
+        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
+        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
+        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
+        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
+        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
+        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
+        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
+        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
+        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
+        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
+        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
+        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
+        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
+        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
+        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
+        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
+        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
+        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
+        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
+        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
+        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
+        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
+        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
+        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
+        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
+        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
+        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
+        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
+        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
+        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
+        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
+        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
+        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
+        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[48547]},\"timeline_lookup\":[[1,127]],\"suggested_topics\":[{\"id\":17389,\"\
+        title\":\"Leveraging open source with Ubuntu Pro on Azure\",\"fancy_title\"\
+        :\"Leveraging open source with Ubuntu Pro on Azure\",\"slug\":\"leveraging-open-source-with-ubuntu-pro-on-azure\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:08:24.599Z\",\"last_posted_at\":\"2020-07-17T16:08:24.765Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:08:24.765Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":132,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17399,\"title\":\"Accelerating IoT device time to market\",\"\
+        fancy_title\":\"Accelerating IoT device time to market\",\"slug\":\"accelerating-iot-device-time-to-market\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T16:19:14.262Z\",\"last_posted_at\":\"2020-07-17T16:19:14.409Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:19:14.409Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":139,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17348,\"title\":\"Creating a cloud-like bare metal experience\
+        \ in the data centre\",\"fancy_title\":\"Creating a cloud-like bare metal\
+        \ experience in the data centre\",\"slug\":\"creating-a-cloud-like-bare-metal-experience-in-the-data-centre\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T14:22:12.095Z\",\"last_posted_at\":\"2020-07-17T14:22:12.222Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T14:22:12.222Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":128,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17356,\"title\":\"How Domotz streamlined provisioning of IoT\
+        \ devices\",\"fancy_title\":\"How Domotz streamlined provisioning of IoT devices\"\
+        ,\"slug\":\"how-domotz-streamlined-provisioning-of-iot-devices\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T14:28:51.877Z\",\"last_posted_at\":\"2020-07-17T14:28:52.017Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T14:28:52.017Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":132,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":19212,\"title\":\"\u5C06Ubuntu\u684C\u9762\u4E0EActive Directory\u96C6\
+        \u6210\",\"fancy_title\":\"\u5C06Ubuntu\u684C\u9762\u4E0EActive Directory\u96C6\
+        \u6210\",\"slug\":\"ubuntu-active-directory\",\"posts_count\":1,\"reply_count\"\
+        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-11-04T18:12:24.665Z\"\
+        ,\"last_posted_at\":\"2020-11-04T18:12:24.844Z\",\"bumped\":true,\"bumped_at\"\
+        :\"2020-11-04T18:12:24.844Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
+        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
+        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
+        :0,\"views\":37,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
+        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
+        \ Poster, Most Recent Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\"\
+        ,\"name\":\"Carlos Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
+        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
+        :\"2020-07-14T09:57:15.561Z\",\"views\":345,\"reply_count\":0,\"like_count\"\
+        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
+        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
+        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
+        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":227,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
+        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
+        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
+        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
+        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
+        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
+        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
+        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
+        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
+        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
+        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
+        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
+        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
+        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
+        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
+        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
+        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
+        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
+        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
+        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
+        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
+        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
+        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
+        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
+        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
+        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
+        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
+        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
+        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
+        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
+        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
+        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
+        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
+        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
+        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
+        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
+        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
+        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
+        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
+        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
+        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
+        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
+        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
+        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
+        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
+        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
+        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
+        :\"ubuntu.com\"}]}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 22:56:43 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Cached:
+      - 'true'
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 3b3a6c55-8743-4d8b-a002-cd51df31f8fc
+      X-Runtime:
+      - '0.003053'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://discourse.ubuntu.com/t/19381.json
+  response:
+    body:
+      string: "{\"post_stream\":{\"posts\":[{\"id\":53739,\"name\":\"Beth Collins\"\
+        ,\"username\":\"bethcollins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"created_at\":\"2020-11-17T09:27:47.898Z\",\"cooked\":\"\\u003cdiv class=\\\
+        \"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003cth\\u003eKey\\u003c/th\\u003e\\n\\u003cth\\u003eValue\\u003c/th\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\\
+        u003ctr\\u003e\\n\\u003ctd\\u003eimage\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eimage_width\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eimage_height\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
+        n\\u003ctr\\u003e\\n\\u003ctd\\u003emeta_image\\u003c/td\\u003e\\n\\u003ctd\\\
+        u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/178bfce7-twitter_wide_banner+%2813%29.jpeg\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/178bfce7-twitter_wide_banner+(13).jpeg\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003emeta_copydoc\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
+        \"https://docs.google.com/document/d/1I4H1gdSa4RpiRHn3ZcG8QwcKY4KrBKpJ9ZpbYAyBipY/edit\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://docs.google.com/document/d/1I4H1gdSa4RpiRHn3ZcG8QwcKY4KrBKpJ9ZpbYAyBipY/edit\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003ebanner_class\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
+        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eform_id\\u003c/td\\\
+        u003e\\n\\u003ctd\\u003e3734\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
+        u003e\\n\\u003ctd\\u003eresource_url\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
+        u003ca href=\\\"https://pages.ubuntu.com/rs/066-EOV-335/images/IT_Accelerate_Kubernetes_enterprise_16.11.20.pdf\\\
+        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://pages.ubuntu.com/rs/066-EOV-335/images/IT_Accelerate_Kubernetes_enterprise_16.11.20.pdf\\\
+        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\\
+        u003ctd\\u003eprimary_cta\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
+        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eprimary_link\\\
+        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003cspan class=\\\"hashtag\\\"\\u003e#the-form\\\
+        u003c/span\\u003e\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\\
+        n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003cp\\u003eMan mano che l\u2019\
+        adozione di Kubernetes si estende dai primi utilizzatori alle imprese pi\xF9\
+        \ lente, molte aziende stanno scoprendo che, mentre i container e Kubernetes\
+        \ offrono vantaggi in termini di sviluppo, velocit\xE0, agilit\xE0 e gestione\
+        \ dei costi, essi creano anche una nuova serie di sfide da superare.\\u003c/p\\\
+        u003e\\n\\u003cp\\u003eMentre ci sono aspetti comuni nei tipi di sfide che\
+        \ le imprese devono affrontare con Kubernetes, non c\u2019\xE8 un vero e proprio\
+        \ modo per gestirle, ma piuttosto una serie di potenziali approcci, ognuno\
+        \ con i propri vantaggi e svantaggi.\\u003c/p\\u003e\\n\\u003cp\\u003eIn questo\
+        \ white paper e webinar esamineremo le motivazioni che la maggior parte delle\
+        \ imprese hanno quando adottano Kubernetes, gli approcci disponibili e le\
+        \ valutazioni da tenere in considerazione a seconda delle dimensioni dell\u2019\
+        impresa, della sua sofisticazione tecnica, dell\u2019infrastruttura attuale\
+        \ e del suo budget.\\u003c/p\\u003e\\n\\u003cp\\u003eScaricate oggi per:\\\
+        u003c/p\\u003e\\n\\u003cul\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eScoprire\
+        \ i principali vantaggi di Kubernetes per l\u2019impresa e perch\xE9 ha conquistato\
+        \ lo spazio di containerizzazione.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\n\\\
+        u003cli\\u003e\\n\\u003cp\\u003eScoprire le sfide pi\xF9 comuni che le imprese\
+        \ devono affrontare nel processo di adozione di Kubernetes.\\u003c/p\\u003e\\\
+        n\\u003c/li\\u003e\\n\\u003cli\\u003e\\n\\u003cp\\u003eOttenere un confronto\
+        \ approfondito delle soluzioni Kubernetes pi\xF9 importanti sul mercato, tra\
+        \ cui: Vanilla, PaaS, distribuzione di Kubernetes in cloud pubblico, gestito,\
+        \ e piattaforma Enterprise Kubernetes.\\u003c/p\\u003e\\n\\u003c/li\\u003e\\\
+        n\\u003c/ul\\u003e\\n\\u003cp\\u003eCinque strategie per accelerare l\u2019\
+        implementazione di Kubernetes nell\u2019impresa\\u003c/p\\u003e\",\"post_number\"\
+        :1,\"post_type\":1,\"updated_at\":\"2020-11-17T09:27:47.898Z\",\"reply_count\"\
+        :0,\"reply_to_post_number\":null,\"quote_count\":0,\"incoming_link_count\"\
+        :5,\"reads\":9,\"score\":26.4,\"yours\":false,\"topic_id\":19381,\"topic_slug\"\
+        :\"cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa\"\
+        ,\"display_username\":\"Beth Collins\",\"primary_group_name\":\"Canonical\"\
+        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
+        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
+        ,\"version\":1,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
+        can_wiki\":false,\"link_counts\":[{\"url\":\"https://pages.ubuntu.com/rs/066-EOV-335/images/IT_Accelerate_Kubernetes_enterprise_16.11.20.pdf\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://docs.google.com/document/d/1I4H1gdSa4RpiRHn3ZcG8QwcKY4KrBKpJ9ZpbYAyBipY/edit\"\
+        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/178bfce7-twitter_wide_banner+%2813%29.jpeg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"178bfce7-twitter_wide_banner+%2813%29.jpeg\"\
+        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
+        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/engage-pages-and-takeovers/17229\"\
+        ,\"internal\":true,\"reflection\":true,\"title\":\"Engage pages and Takeovers\"\
+        ,\"clicks\":0}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
+        moderator\":true,\"admin\":false,\"staff\":true,\"user_id\":12532,\"hidden\"\
+        :false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
+        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
+        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
+        :[53739]},\"timeline_lookup\":[[1,1]],\"suggested_topics\":[{\"id\":17327,\"\
+        title\":\"North America\u2018s first autonomous runway snowplough\",\"fancy_title\"\
+        :\"North America\u2018s first autonomous runway snowplough\",\"slug\":\"north-america-s-first-autonomous-runway-snowplough\"\
+        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
+        :null,\"created_at\":\"2020-07-17T12:58:41.650Z\",\"last_posted_at\":\"2020-07-17T12:58:41.789Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:58:41.789Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":120,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17241,\"title\":\"Canonical presents Financial Services Month\"\
+        ,\"fancy_title\":\"Canonical presents Financial Services Month\",\"slug\"\
+        :\"canonical-presents-financial-services-month\",\"posts_count\":1,\"reply_count\"\
+        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-15T08:00:34.339Z\"\
+        ,\"last_posted_at\":\"2020-07-15T08:00:34.495Z\",\"bumped\":true,\"bumped_at\"\
+        :\"2020-07-17T12:33:05.036Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
+        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
+        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
+        :0,\"views\":132,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
+        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
+        \ Poster, Most Recent Poster\",\"user\":{\"id\":320,\"username\":\"peterm-ubuntu\"\
+        ,\"name\":\"Peter Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
+        }}]},{\"id\":17245,\"title\":\"How to get started and progress with an AI\
+        \ program\",\"fancy_title\":\"How to get started and progress with an AI program\"\
+        ,\"slug\":\"how-to-get-started-and-progress-with-an-ai-program\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-15T09:09:13.469Z\",\"last_posted_at\":\"2020-07-15T09:09:13.896Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:24:12.975Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":131,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]},{\"id\":17291,\"title\":\"Cloud init\",\"fancy_title\":\"Cloud init\"\
+        ,\"slug\":\"cloud-init\",\"posts_count\":1,\"reply_count\":0,\"highest_post_number\"\
+        :1,\"image_url\":null,\"created_at\":\"2020-07-17T10:43:31.644Z\",\"last_posted_at\"\
+        :\"2020-07-17T10:43:31.781Z\",\"bumped\":true,\"bumped_at\":\"2020-07-17T10:43:31.781Z\"\
+        ,\"unseen\":false,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\"\
+        :false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"\
+        archetype\":\"regular\",\"like_count\":0,\"views\":148,\"category_id\":51,\"\
+        featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\"\
+        :\"latest single\",\"description\":\"Original Poster, Most Recent Poster\"\
+        ,\"user\":{\"id\":11720,\"username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\"\
+        :\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}}]},{\"\
+        id\":17330,\"title\":\"Telcos and Service Providers expect near 100% uptime\"\
+        ,\"fancy_title\":\"Telcos and Service Providers expect near 100% uptime\"\
+        ,\"slug\":\"telcos-and-service-providers-expect-near-100-uptime\",\"posts_count\"\
+        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
+        :\"2020-07-17T13:01:42.602Z\",\"last_posted_at\":\"2020-07-17T13:01:42.707Z\"\
+        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T13:01:42.707Z\",\"unseen\":false,\"\
+        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
+        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
+        ,\"like_count\":0,\"views\":103,\"category_id\":51,\"featured_link\":null,\"\
+        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
+        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
+        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}]}],\"tags\":[],\"id\":19381,\"title\":\"Cinque strategie per accelerare\
+        \ l'implementazione di Kubernetes nell'impresa\",\"fancy_title\":\"Cinque\
+        \ strategie per accelerare l\\u0026rsquo;implementazione di Kubernetes nell\\\
+        u0026rsquo;impresa\",\"posts_count\":1,\"created_at\":\"2020-11-17T09:27:47.699Z\"\
+        ,\"views\":36,\"reply_count\":0,\"like_count\":0,\"last_posted_at\":\"2020-11-17T09:27:47.898Z\"\
+        ,\"visible\":true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"\
+        archetype\":\"regular\",\"slug\":\"cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa\"\
+        ,\"category_id\":51,\"word_count\":269,\"deleted_at\":null,\"user_id\":12532,\"\
+        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\"\
+        :null,\"draft\":null,\"draft_key\":\"topic_19381\",\"draft_sequence\":null,\"\
+        unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\"\
+        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
+        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
+        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
+        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":6,\"\
+        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
+        :[{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth Collins\",\"\
+        avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
+        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
+        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":12532,\"\
+        username\":\"bethcollins\",\"name\":\"Beth Collins\",\"avatar_template\":\"\
+        /letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        },\"last_poster\":{\"id\":12532,\"username\":\"bethcollins\",\"name\":\"Beth\
+        \ Collins\",\"avatar_template\":\"/letter_avatar/bethcollins/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
+        }}}"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
+        User-Api-Key, User-Api-Client-Id
+      Access-Control-Allow-Methods:
+      - POST, PUT, GET, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - https://didrocks.fr
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 18 Nov 2020 22:56:44 GMT
+      Keep-Alive:
+      - timeout=5, max=99
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - Apache/2.4.18 (Ubuntu)
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Discourse-Route:
+      - topics/show
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 0a3c5db1-5a10-4f9f-8112-5428b612180d
+      X-Runtime:
+      - '0.109422'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/templates/engage.html
+++ b/tests/fixtures/templates/engage.html
@@ -1,0 +1,3 @@
+{% if 'active' in document['metadata'] and document['metadata']['active'] == "false" %}
+    <meta name="robots" content="nofollow" />
+{% endif %}


### PR DESCRIPTION
Redirect inactive engage page to discourse unless there is a `preview` flag.

## QA
For the sake of the QA I made /engage/it/deployment-azienda-manuale active = false. It will not affect prod in any way because the feature is not live yet.

1. Go to https://ubuntu-com-8761.demos.haus/engage/it/deployment-azienda-manuale you will be redirected to its discourse page.
2. Go to https://ubuntu-com-8761.demos.haus/engage/it/deployment-azienda-manuale?preview you will see the page
Press `ctrl + u` in browser. Use search to look for the meta tag robot. You will see it has the value `nofollow`.
3.  Go to https://ubuntu-com-8761.demos.haus/engage/it/redhat-openstack-confronto-manuale (an active page). Press `ctrl + u` in browser. Use search to look for the meta tag `robot`. It won't be there.

## Issue

Fixes: https://github.com/canonical-web-and-design/web-squad/issues/3404 