### PR TITLE
Rename DocParser to TutorialParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ You can add the extension on your project as follows, replacing, at least, `base
 
 ```python
 import talisker.requests
-from canonicalwebteam.discourse import Docs, DocParser, DiscourseAPI
+from canonicalwebteam.discourse import DiscourseAPI, Tutorials, TutorialParser
 
 app = Flask("myapp")
 session = talisker.requests.get_session()
 
-discourse = Docs(
-    parser=DocParser(
+discourse = Tutorials(
+    parser=TutorialParser(
         api=DiscourseAPI(
             base_url="https://forum.example.com/", session=session
         ),

--- a/canonicalwebteam/discourse/__init__.py
+++ b/canonicalwebteam/discourse/__init__.py
@@ -1,9 +1,9 @@
 from canonicalwebteam.discourse.app import (  # noqa
-    Docs,  # noqa
+    Tutorials,  # noqa
     EngagePages,  # noqa
 )
 from canonicalwebteam.discourse.models import DiscourseAPI  # noqa
 from canonicalwebteam.discourse.parsers import (  # noqa
-    DocParser,  # noqa
+    TutorialParser,  # noqa
     EngageParser,  # noqa
 )

--- a/canonicalwebteam/discourse/app.py
+++ b/canonicalwebteam/discourse/app.py
@@ -98,7 +98,7 @@ class Discourse:
         app.register_blueprint(self.blueprint, url_prefix=self.url_prefix)
 
 
-class Docs(Discourse):
+class Tutorials(Discourse):
     """
     A Flask extension object to create a Blueprint
     to serve documentation pages, pulling the documentation content
@@ -115,9 +115,9 @@ class Docs(Discourse):
     def __init__(
         self,
         parser,
-        document_template="docs/document.html",
-        url_prefix="/docs",
-        blueprint_name="docs",
+        document_template="tutorials/document.html",
+        url_prefix="/tutorials",
+        blueprint_name="tutorials",
     ):
         super().__init__(parser, document_template, url_prefix, blueprint_name)
         category_id = self.parser.category_id

--- a/canonicalwebteam/discourse/parsers/__init__.py
+++ b/canonicalwebteam/discourse/parsers/__init__.py
@@ -1,4 +1,6 @@
-from canonicalwebteam.discourse.parsers.docs_parser import DocParser  # noqa
+from canonicalwebteam.discourse.parsers.tutorials_parser import (  # noqa
+    TutorialParser,  # noqa
+)
 from canonicalwebteam.discourse.parsers.engage_parser import (  # noqa
     EngageParser,  # noqa
 )

--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -14,7 +14,7 @@ TOPIC_URL_MATCH = re.compile(
 
 class BaseParser(object):
     """
-    Parsers used commonly by Docs and Engage pages
+    Parsers used commonly by Tutorials and Engage pages
     """
 
     def _get_section(self, soup, title_text):

--- a/canonicalwebteam/discourse/parsers/tutorials_parser.py
+++ b/canonicalwebteam/discourse/parsers/tutorials_parser.py
@@ -22,7 +22,7 @@ from canonicalwebteam.discourse.parsers.base_parser import (
 )
 
 
-class DocParser(BaseParser):
+class TutorialParser(BaseParser):
     def __init__(self, api, index_topic_id, url_prefix, category_id=None):
         self.api = api
         self.index_topic_id = index_topic_id

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="2.1.0",
+    version="3.0.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",
@@ -21,7 +21,9 @@ setup(
         "humanize",
         "python-dateutil",
         "validators",
-        "vcrpy-unittest",
     ],
-    tests_require=["responses", "requests-mock", "httpretty"],
+    tests_require=[
+        "vcrpy-unittest",
+        "httpretty",
+    ],
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,7 +10,7 @@ import requests
 from bs4 import BeautifulSoup
 
 # Local
-from canonicalwebteam.discourse import Docs, DiscourseAPI, DocParser
+from canonicalwebteam.discourse import DiscourseAPI, Tutorials, TutorialParser
 from canonicalwebteam.discourse.parsers.base_parser import TOPIC_URL_MATCH
 from tests.fixtures.forum_mock import register_uris
 
@@ -64,8 +64,8 @@ class TestApp(unittest.TestCase):
             session=requests.Session(),
         )
 
-        Docs(
-            parser=DocParser(
+        Tutorials(
+            parser=TutorialParser(
                 api=discourse_api,
                 category_id=2,
                 index_topic_id=34,
@@ -75,8 +75,8 @@ class TestApp(unittest.TestCase):
             url_prefix="/",
         ).init_app(app)
 
-        Docs(
-            parser=DocParser(
+        Tutorials(
+            parser=TutorialParser(
                 api=discourse_api,
                 category_id=2,
                 index_topic_id=42,
@@ -86,8 +86,8 @@ class TestApp(unittest.TestCase):
             url_prefix="/",
         ).init_app(app_no_nav)
 
-        Docs(
-            parser=DocParser(
+        Tutorials(
+            parser=TutorialParser(
                 api=discourse_api,
                 category_id=2,
                 index_topic_id=35,
@@ -97,8 +97,8 @@ class TestApp(unittest.TestCase):
             url_prefix="/",
         ).init_app(app_no_mappings)
 
-        Docs(
-            parser=DocParser(
+        Tutorials(
+            parser=TutorialParser(
                 api=discourse_api,
                 category_id=2,
                 index_topic_id=36,
@@ -108,20 +108,20 @@ class TestApp(unittest.TestCase):
             url_prefix="/",
         ).init_app(app_broken_mappings)
 
-        Docs(
-            parser=DocParser(
+        Tutorials(
+            parser=TutorialParser(
                 api=discourse_api, index_topic_id=37, url_prefix="/"
             ),
             document_template="document.html",
             url_prefix="/",
         ).init_app(app_no_category)
 
-        Docs(
-            parser=DocParser(
+        Tutorials(
+            parser=TutorialParser(
                 api=discourse_api, index_topic_id=38, url_prefix="/docs"
             ),
             document_template="document.html",
-            url_prefix="/docs",
+            url_prefix="/tutorials",
         ).init_app(app_url_prefix)
 
         self.client = app.test_client()
@@ -251,9 +251,9 @@ class TestApp(unittest.TestCase):
         response = self.client.get("/a")
         response_2 = self.client_no_mappings.get("/a")
         response_3 = self.client_no_category.get("/a")
-        response_4 = self.client_url_prefix.get("/docs/a")
-        response_5 = self.client_url_prefix.get("/docs/b")
-        response_6 = self.client_url_prefix.get("/docs/c")
+        response_4 = self.client_url_prefix.get("/tutorials/a")
+        response_5 = self.client_url_prefix.get("/tutorials/b")
+        response_6 = self.client_url_prefix.get("/tutorials/c")
 
         # Check pretty URL fails when no mapping
         self.assertEqual(response_2.status_code, 404)


### PR DESCRIPTION
## Done

- Rename DocParser to TutorialParser, fixes https://github.com/canonical-web-and-design/canonicalwebteam.discourse/issues/59