### PR TITLE
Add id to headings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,3 +31,4 @@ v2.0.3, 2020-10-22 -- Remove meta div that breaks Vanilla
 v2.0.4, 2020-11-12 -- Make url prefix optional on url map
 v2.0.5, 2020-11-18 -- Add preview option for inactive pages
 v2.1.0, 2020-11-20 -- Add sitemap.xml endpoint
+v2.1.1, 2020-11-20 -- Add id to headings

--- a/canonicalwebteam/discourse/parsers/docs_parser.py
+++ b/canonicalwebteam/discourse/parsers/docs_parser.py
@@ -170,6 +170,7 @@ class DocParser(BaseParser):
         soup = self._replace_notes_to_editors(soup)
         soup = self._replace_links(soup)
         soup = self._replace_polls(soup)
+        soup = self._add_anchors_headers(soup)
 
         return soup
 
@@ -513,6 +514,19 @@ class DocParser(BaseParser):
                 blockquote.replace_with(
                     BeautifulSoup(notification, features="html.parser")
                 )
+
+        return soup
+
+    def _add_anchors_headers(self, soup):
+        """
+        Adds id anchors to all headers
+        E.g. <h2>Heading</h2> becomes <h2 id="heading">Heading</h2>
+        """
+        for heading in soup.find_all(["h2", "h3", "h4", "h5", "h6"]):
+            heading_id = (
+                heading.text.replace(" ", "-").replace(", ", "-").lower()
+            )
+            heading.attrs["id"] = heading_id
 
         return soup
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="2.1.0",
+    version="2.1.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
## Done

- Add id to headings so that we can support anchors for docs
`<h2>Heading</h2>`
becomes
`<h2 id="heading">Heading</h2>`

## QA
Easiest way to QA is to `print(soup)` as this will be applied to any project.
Or you can also add it to a project and check the docs have h2, h3, h4, h5 have ids
Or use my [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/8934)
