### PR TITLE
Nav table: Ignore levels higher than 3

### DIFF
--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -379,6 +379,10 @@ class DocParser(BaseParser):
                 )
 
             for node in nav_items:
+                # Ignore levels higher than 3
+                if node["level"] > 3:
+                    continue
+
                 last = root
                 for _ in range(node["level"]):
                     last = last["children"][-1]


### PR DESCRIPTION
## Done

- Nav table: Ignore levels higher than 3 (https://github.com/canonical-web-and-design/snap-squad/issues/1786)

**I didn't increase the version number because I want this change to be part of the next release.**

## QA

It's already QAed by me

1. Clone dqlite locally
2. Change the discourse topic
3. Create a navigation table with more than 3 levels