### PR TITLE
Fix for relative links on Discourse

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -517,7 +517,10 @@ class BaseParser:
                             path=self.redirect_map[full_path]
                         )
                     else:
-                        url_parts = url_parts._replace(path=full_link)
+                        absolute_link = os.path.join(
+                            self.api.base_url, link.lstrip("/")
+                        )
+                        url_parts = url_parts._replace(path=absolute_link)
 
                     a["href"] = urlunparse(url_parts)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="3.0.7",
+    version="3.0.8",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -162,7 +162,8 @@ class TestApp(unittest.TestCase):
             "<h1>Navigation</h1>", soup.find("main").decode_contents()
         )
         self.assertIn(
-            '<li><a href="/t/b-page/12">B page</a></li>',
+            '<li><a href="https://discourse.example.com/t/b-page/12">'
+            "B page</a></li>",
             soup.find("nav").decode_contents(),
         )
 
@@ -202,11 +203,12 @@ class TestApp(unittest.TestCase):
             "<h1>Navigation</h1>", soup.find("main").decode_contents()
         )
         self.assertIn(
-            '<a href="/t/page-a/10">Page A</a>',
+            '<a href="https://discourse.example.com/t/page-a/10">Page A</a>',
             soup.find("nav").decode_contents(),
         )
         self.assertIn(
-            '<li><a href="/t/b-page/12">B page</a></li>',
+            '<li><a href="https://discourse.example.com/t/b-page/12">'
+            "B page</a></li>",
             soup.find("nav").decode_contents(),
         )
 
@@ -238,7 +240,7 @@ class TestApp(unittest.TestCase):
 
         # Check navigation
         self.assertIn(
-            '<a href="/t/b-page/12">B page</a>',
+            '<a href="https://discourse.example.com/t/b-page/12">B page</a>',
             soup.find("nav").decode_contents(),
         )
 
@@ -277,7 +279,7 @@ class TestApp(unittest.TestCase):
 
         # Check navigation
         self.assertIn(
-            '<a href="/t/b-page/12">B page</a>',
+            '<a href="https://discourse.example.com/t/b-page/12">B page</a>',
             soup.find("nav").decode_contents(),
         )
 


### PR DESCRIPTION
## Done

When there are relative links on Discourse topics that are not part of the URL mapping, the parser keeps the same relative path creating a bad URL, like:

`/t/setting-up-static-kubernetes-storage-tutorial/1193` => `juju.is/t/setting-up-static-kubernetes-storage-tutorial/1193`

With this change, these relative paths will be transformed into absolute paths linking to the Discourse topic if the path is not part of the URL mapping.

## QA

QA on juju.is: https://github.com/canonical-web-and-design/juju.is/pull/174