### PR TITLE
User references in posts should link to the user's discourse profile

### DIFF
--- a/canonicalwebteam/discourse/parsers/base_parser.py
+++ b/canonicalwebteam/discourse/parsers/base_parser.py
@@ -500,8 +500,15 @@ class BaseParser:
         for a in soup.findAll("a"):
             full_link = a.get("href", "")
             self._replace_text_link(a, topics)
-            link = full_link.replace(self.api.base_url, "")
 
+            # For user references link to discourse profile pages
+            if full_link.startswith("/u") and a.string.startswith("@"):
+                a["href"] = os.path.join(
+                    self.api.base_url, full_link.lstrip("/")
+                )
+                continue
+
+            link = full_link.replace(self.api.base_url, "")
             if link.startswith("/"):
                 link_match = TOPIC_URL_MATCH.match(link)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="4.0.0",
+    version="4.0.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import MagicMock
+from canonicalwebteam.discourse.parsers.base_parser import BaseParser
+
+
+class TestParser(unittest.TestCase):
+    def test_parser_username_link(self):
+
+        discourse_api_mock = MagicMock()
+        discourse_api_mock.base_url = "https://base.url"
+
+        parser = BaseParser(
+            api=discourse_api_mock,
+            index_topic_id=1,
+            url_prefix="/",
+        )
+
+        parsed_topic = parser.parse_topic(
+            {
+                "id": 1,
+                "category_id": 1,
+                "title": "Sample",
+                "slug": "sample",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 11,
+                            "cooked": (
+                                "<a href='/u/evilnick'>@evilnick</a>"
+                                "<a>No Link</a>"
+                                "<a></a>"
+                            ),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertIn(
+            '<a href="https://base.url/u/evilnick">@evilnick</a>',
+            parsed_topic["body_html"],
+        )


### PR DESCRIPTION
# Done
Make user references in discourse posts link to their discourse profile.
Ex: Parsing `<a href="/u/joao.martins">@joao.martins</a>` in discourse.ubuntu.com post should result in `<a href="https://discourse.ubuntu.com/u/joao.martins">@joao.martins</a>`

# QA
Use https://github.com/canonical-web-and-design/webteam.canonical.com/pull/53 to QA.

Enables fixing of #99 we need to bump `microk8s.io` to `canonicalwebteam.discourse==4.0.1`