### PR TITLE
Allow different fragments on navigation links pointing to the same topic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="4.0.1",
+    version="4.0.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
If we had multiple navigation links pointing at different fragments of the same
topic the fragments would be overwritten by the fragment of the last processed
link when building the URL map.