### PR TITLE
Hidden nav items

### DIFF
--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -374,6 +374,12 @@ class DocParser(BaseParser):
             for row in navigation_table:
                 item = {}
                 level = row.select_one("td:first-child").text
+                hidden = False
+
+                # Empty levels are possible to allow URLs mapping
+                if len(level) == 0:
+                    hidden = True
+                    level = "0"
 
                 if not level.isnumeric() or int(level) < 0:
                     self.warnings.append(f"Invalid level used: {level}")
@@ -394,11 +400,12 @@ class DocParser(BaseParser):
 
                 parsed_path = urlparse(path)
                 parsed_href = urlparse(navlink_href)
-                item["level"] = int(level)
+                item["hidden"] = hidden
+                item["level"] = int(level) if level else None
                 item["path"] = parsed_path.path
                 item["navlink_href"] = navlink_href
                 item["navlink_fragment"] = parsed_href.fragment
-                item["navlink_text"] = navlink_text
+                item["navlink_text"] = navlink_text if not hidden else ""
                 item["children"] = []
 
                 nav_items.append(item)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="4.0.3",
+    version="4.0.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
## Done

- Allow doc writers to use empty levels in the navigation table. Empty levels will allow URL mapping without displaying them in the navigation

Fixes https://github.com/canonical-web-and-design/snap-squad/issues/2144