### PR TITLE
Fix unexpected render of any discourse topic

### DIFF
--- a/canonicalwebteam/discourse/parsers/docs.py
+++ b/canonicalwebteam/discourse/parsers/docs.py
@@ -162,6 +162,8 @@ class DocParser(BaseParser):
                     full_path,
                     target_url=self.url_map_versions[version][topic_id],
                 )
+            else:
+                raise PathNotFoundError(full_path)
 
         return topic_id, version
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse",
-    version="4.0.4",
+    version="4.0.5",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
## Done

- Fix unexpected render of a random discourse topics

## QA

- Add `git+git://github.com/carkod/canonicalwebteam.discourse@unexpected-render#egg=canonicalwebteam.discourse` to your requirements.txt on ubuntu.com repo.
- `dotrun clean && dotrun` the project and check that e.g. http://localhost:8001/server/docs/t/nvidia-driver-specific-flutter-bug/25269 is returning a 404.
- Compare with current https://ubuntu.com/server/docs/t/nvidia-driver-specific-flutter-bug/25269 is returning a page, this shouldn't happen.

Additionally, to be 100% sure we are not breaking other docs (if any of the other docs have some obscure feature), we can try the same thing on anbox-cloud.io/docs/t/nvidia-driver-specific-flutter-bug/25269, maas.io/docs/t/nvidia-driver-specific-flutter-bug/25269, ubuntu.com/openstack/install which also pull content from discourse see if there are any issues.

## Issues
Fixes #114 