### PR TITLE
Use non-expandable navigation by default

### DIFF
--- a/examples/document.html
+++ b/examples/document.html
@@ -70,7 +70,7 @@
               Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
               Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
             #}
-            {{ create_navigation(nav_group.children, expandable=True) }}
+            {{ create_navigation(nav_group.children, expandable=False) }}
           {% endfor %}
         </div>
       </div>


### PR DESCRIPTION
By default the example should use the fully expanded side navigation.