### PR TITLE
Expand items that are not linked in navigation

### DIFF
--- a/examples/document.html
+++ b/examples/document.html
@@ -15,7 +15,13 @@
       {% endif %}
 
       {% if expandable %}
-        {% if element.children and (element.is_active or element.has_active_child) %}
+        {% if element.navlink_href %}
+          {# if the element is a link to a page, expand it only when it's active #}
+          {% if element.children and (element.is_active or element.has_active_child) %}
+            {{ create_navigation(element.children, True) }}
+          {% endif %}
+        {% else %}
+          {# if the element is NOT a link to a page, ALWAYS expand it #}
           {{ create_navigation(element.children, True) }}
         {% endif %}
       {% else %}


### PR DESCRIPTION
Makes sure the nested navigation items are always expanded if their parent does not have a page linked (in the expandable side navigation).

This is based on enhancement introduced in [multipass.run docs template](https://github.com/canonical-web-and-design/multipass.run/blob/21155dbd029ac3569c1e1c3388a5f7cb0671355b/templates/docs/document.html#L6-L34)